### PR TITLE
Hotfix 3.1.2 -- API bugfixes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,9 +2,13 @@
 
 ## V3.1.2 -- REST API Hotfix
 
-Version 3.1.2 is a bug fix release that addresses an issue in the REST API specification.
+Version 3.1.2 is a bug fix release that addresses two issues in the REST API specification, and one in the edge message format:
 
-* The REC REST API specification (api/REST/rec-full-v3.1.2.yaml) now specifies that the payload for POST, PUT, and PATCH operations should be carried in the HTTP request body.
+* The REC REST API specification now specifies that the payload for POST, PUT, and PATCH operations should be carried in the HTTP request body.
+* The REC REST API specification now uses the updated MIME type for JSON-LD: application/ld+json
+* The Edge message examples mistakenly carried REC 2 semantics due to previous Git mishap; that is now addressed and the examples are up-to-date
+
+Note that this hotfix does not affect the ontology semantics; aside from version and release node annotations, REC 3.1.2 is identical to REC 3.1.2.
 
 ## V3.1.1 -- REST API
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # RealEstateCore Release Notes
 
+## V3.1.2 -- REST API Hotfix
+
+Version 3.1.2 is a bug fix release that addresses an issue in the REST API specification.
+
+* The REC REST API specification (api/REST/rec-full-v3.1.2.yaml) now specifies that the payload for POST, PUT, and PATCH operations should be carried in the HTTP request body.
+
 ## V3.1.1 -- REST API
 
 Version 3.1.1 is a minor release of REC that contains:

--- a/api/REST/RealEstateCore_REST_specification.md
+++ b/api/REST/RealEstateCore_REST_specification.md
@@ -4,7 +4,7 @@ _This specification defines the first version of the RealEstateCore REST API._
 
 _It comprises a non-normative section where principles for the REST API is described. And a normative section where requirements for being and API to be "RealEstateCore Compliant" are stated._
 
-_Formally, the API is specified via an Open API Specification (formerly Swagger API) generated from the OWL ontology, and from which the normative requirements section below stems. See [OAS Spec](https://github.com/RealEstateCore/rec/blob/3.1.1/api/REST/rec-full-v3.1.1.yaml)._
+_Formally, the API is specified via an Open API Specification (formerly Swagger API) generated from the OWL ontology, and from which the normative requirements section below stems. See [OAS Spec](https://github.com/RealEstateCore/rec/blob/3.1.2/api/REST/rec-full-v3.1.2.yaml)._
 
 _Throughout this specification RealEstateCore may be abbreviated to REC._
 
@@ -29,7 +29,7 @@ Additional functionality may be implemented and a mechanism to understanding suc
 
 **Principle.** In addition to the minimum set of requirements, the specification comprises optional requirements which must be followed _if chosen to be included_ in an API implementation (designated _"should"_).
 
-![Requirement Diagram](https://github.com/RealEstateCore/rec/blob/3.1.1/api/REST/REC_API_Requirement_diagram.png)
+![Requirement Diagram](https://github.com/RealEstateCore/rec/blob/3.1.2/api/REST/REC_API_Requirement_diagram.png)
 
 Furthermore, recommendations are expressed for areas where the REC Consortium considers to add requirements in the future. 
 

--- a/api/REST/rec-full-v3.1.1.yaml
+++ b/api/REST/rec-full-v3.1.1.yaml
@@ -5,7 +5,7 @@ info:
     name: MIT
     url: https://opensource.org/licenses/MIT
   description: The documentation below is automatically extracted from a <dc:description> annotation on the ontology https://w3id.org/rec/full/:<br/><br/>*This ontology imports all RealEstateCore (REC) modules and thus gives the fullest expressivity that REC allows. You can use this ontology as-is, or you can construct your own ontology by importing individual REC modules.*
-  version: "3.1.1"
+  version: "3.1.2"
 components:
   parameters:
     pageParam:
@@ -1232,42 +1232,42 @@ paths:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/full/3.1.1/
+                    - https://w3id.org/rec/full/3.1.2/
                   actuation:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/actuation/3.1.1/
+                    - https://w3id.org/rec/actuation/3.1.2/
                   device:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/device/3.1.1/
+                    - https://w3id.org/rec/device/3.1.2/
                   core:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/core/3.1.1/
+                    - https://w3id.org/rec/core/3.1.2/
                   metadata:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/metadata/3.1.1/
+                    - https://w3id.org/rec/metadata/3.1.2/
                   agents:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/agents/3.1.1/
+                    - https://w3id.org/rec/agents/3.1.2/
                   building:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/building/3.1.1/
+                    - https://w3id.org/rec/building/3.1.2/
                   lease:
                     type: string
                     format: uri
                     enum:
-                    - https://w3id.org/rec/lease/3.1.1/
+                    - https://w3id.org/rec/lease/3.1.2/
       tags: []
   /actuationinterface:
     get:

--- a/api/REST/rec-full-v3.1.2.yaml
+++ b/api/REST/rec-full-v3.1.2.yaml
@@ -189,16 +189,6 @@ components:
           default: device:Actuator
         label:
           type: string
-        device:devicePlacementContext:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: device:PlacementContext
         core:hasSuperDevice:
           type: object
           required:
@@ -219,6 +209,16 @@ components:
             '@type':
               type: string
               default: core:BuildingComponent
+        core:quantityKind:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:QuantityKind
         device:observedBy:
           type: array
           items:
@@ -230,17 +230,7 @@ components:
                 type: string
               '@type':
                 type: string
-                default: device:Sensor
-        core:deviceQuantityKind:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: core:QuantityKind
+                default: core:Sensor
         device:hasCommunicationsBus:
           type: array
           items:
@@ -352,18 +342,6 @@ components:
               '@type':
                 type: string
                 default: core:Event
-        core:deviceMeasurementUnit:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:MeasurementUnit
         core:hasSubDevice:
           type: array
           items:
@@ -470,7 +448,7 @@ components:
           default: device:Sensor
         label:
           type: string
-        device:devicePlacementContext:
+        core:hasSuperDevice:
           type: object
           required:
           - '@id'
@@ -479,7 +457,540 @@ components:
               type: string
             '@type':
               type: string
-              default: device:PlacementContext
+              default: core:Device
+        core:isMountedInBuildingComponent:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:BuildingComponent
+        core:measurementUnit:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:MeasurementUnit
+          minItems: 1
+        core:quantityKind:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:QuantityKind
+        device:observesActuator:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:Actuator
+        device:hasCommunicationsBus:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:CommunicationsBus
+        device:hasDeviceFunctionType:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:DeviceFunctionType
+        device:hasKNXDataPointType:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:KNXDataPointType
+        device:hasModbusDataType:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:ModbusDataType
+        device:hasModbusFunctionCode:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:ModbusFunctionCode
+        device:hasIPAddressPort:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasKNXDeviceId:
+          type: array
+          items:
+            type: string
+        device:hasKNXDevicePort:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasLoraDevEUI:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasModbusNodeId:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasModbusRegister:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasOffset:
+          type: array
+          items:
+            type: number
+            format: double
+        device:hasScaleFactor:
+          type: array
+          items:
+            type: number
+            format: double
+        core:associatedWithEvent:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Event
+        core:hasSubDevice:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Device
+        core:servesBuilding:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Building
+        core:servesBuildingComponent:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:BuildingComponent
+        core:servesDevice:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Device
+    core:BuildingComponent:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:BuildingComponent
+        label:
+          type: string
+        core:hasSuperBuildingComponent:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:BuildingComponent
+        core:isPartOfBuilding:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:Building
+        core:hasSubBuildingComponent:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:BuildingComponent
+    core:Device:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:Device
+        label:
+          type: string
+        core:hasSuperDevice:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:Device
+        core:isMountedInBuildingComponent:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:BuildingComponent
+        device:hasCommunicationsBus:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:CommunicationsBus
+        device:hasDeviceFunctionType:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:DeviceFunctionType
+        device:hasKNXDataPointType:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:KNXDataPointType
+        device:hasModbusDataType:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:ModbusDataType
+        device:hasModbusFunctionCode:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: device:ModbusFunctionCode
+        device:hasIPAddressPort:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasKNXDeviceId:
+          type: array
+          items:
+            type: string
+        device:hasKNXDevicePort:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasLoraDevEUI:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasModbusNodeId:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasModbusRegister:
+          type: array
+          items:
+            type: integer
+            format: int32
+        device:hasOffset:
+          type: array
+          items:
+            type: number
+            format: double
+        device:hasScaleFactor:
+          type: array
+          items:
+            type: number
+            format: double
+        core:associatedWithEvent:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Event
+        core:hasSubDevice:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Device
+        core:servesBuilding:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Building
+        core:servesBuildingComponent:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:BuildingComponent
+        core:servesDevice:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:Device
+    core:MeasurementUnit:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:MeasurementUnit
+        label:
+          type: string
+    core:QuantityKind:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:QuantityKind
+        label:
+          type: string
+        core:measurementUnit:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:MeasurementUnit
+    core:RealEstate:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:RealEstate
+        label:
+          type: string
+        core:hasRealEstateComponent:
+          type: array
+          items:
+            type: object
+            required:
+            - '@id'
+            properties:
+              '@id':
+                type: string
+              '@type':
+                type: string
+                default: core:RealEstateComponent
+    core:RealEstateComponent:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:RealEstateComponent
+        label:
+          type: string
+        core:isPartOfRealEstate:
+          type: object
+          required:
+          - '@id'
+          properties:
+            '@id':
+              type: string
+            '@type':
+              type: string
+              default: core:RealEstate
+    core:Sensor:
+      type: object
+      required:
+      - '@context'
+      properties:
+        '@id':
+          type: string
+        '@type':
+          type: string
+          default: core:Sensor
+        label:
+          type: string
         core:hasSuperDevice:
           type: object
           required:
@@ -512,7 +1023,7 @@ components:
               '@type':
                 type: string
                 default: device:Actuator
-        core:deviceMeasurementUnit:
+        core:measurementUnit:
           type: array
           items:
             type: object
@@ -525,7 +1036,7 @@ components:
                 type: string
                 default: core:MeasurementUnit
           minItems: 1
-        core:deviceQuantityKind:
+        core:quantityKind:
           type: object
           required:
           - '@id'
@@ -706,7 +1217,7 @@ components:
               '@type':
                 type: string
                 default: device:Exception
-        device:generatedObservation:
+        core:generatedObservation:
           type: array
           items:
             type: object
@@ -717,370 +1228,7 @@ components:
                 type: string
               '@type':
                 type: string
-                default: device:Observation
-    core:BuildingComponent:
-      type: object
-      required:
-      - '@context'
-      properties:
-        '@id':
-          type: string
-        '@type':
-          type: string
-          default: core:BuildingComponent
-        label:
-          type: string
-        core:hasSuperBuildingComponent:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: core:BuildingComponent
-        core:isPartOfBuilding:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: core:Building
-        core:containsMountedDevice:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:Device
-        core:hasSubBuildingComponent:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:BuildingComponent
-    core:Device:
-      type: object
-      required:
-      - '@context'
-      properties:
-        '@id':
-          type: string
-        '@type':
-          type: string
-          default: core:Device
-        label:
-          type: string
-        device:devicePlacementContext:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: device:PlacementContext
-        core:hasSuperDevice:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: core:Device
-        core:isMountedInBuildingComponent:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: core:BuildingComponent
-        device:hasCommunicationsBus:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: device:CommunicationsBus
-        device:hasDeviceFunctionType:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: device:DeviceFunctionType
-        device:hasKNXDataPointType:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: device:KNXDataPointType
-        device:hasModbusDataType:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: device:ModbusDataType
-        device:hasModbusFunctionCode:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: device:ModbusFunctionCode
-        device:hasIPAddressPort:
-          type: array
-          items:
-            type: integer
-            format: int32
-        device:hasKNXDeviceId:
-          type: array
-          items:
-            type: string
-        device:hasKNXDevicePort:
-          type: array
-          items:
-            type: integer
-            format: int32
-        device:hasLoraDevEUI:
-          type: array
-          items:
-            type: integer
-            format: int32
-        device:hasModbusNodeId:
-          type: array
-          items:
-            type: integer
-            format: int32
-        device:hasModbusRegister:
-          type: array
-          items:
-            type: integer
-            format: int32
-        device:hasOffset:
-          type: array
-          items:
-            type: number
-            format: double
-        device:hasScaleFactor:
-          type: array
-          items:
-            type: number
-            format: double
-        core:associatedWithEvent:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:Event
-        core:deviceMeasurementUnit:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:MeasurementUnit
-        core:deviceQuantityKind:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:QuantityKind
-        core:hasSubDevice:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:Device
-        core:servesBuilding:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:Building
-        core:servesBuildingComponent:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:BuildingComponent
-        core:servesDevice:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:Device
-    core:MeasurementUnit:
-      type: object
-      required:
-      - '@context'
-      properties:
-        '@id':
-          type: string
-        '@type':
-          type: string
-          default: core:MeasurementUnit
-        label:
-          type: string
-    core:QuantityKind:
-      type: object
-      required:
-      - '@context'
-      properties:
-        '@id':
-          type: string
-        '@type':
-          type: string
-          default: core:QuantityKind
-        label:
-          type: string
-        core:qkMeasurementUnit:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:MeasurementUnit
-    core:RealEstate:
-      type: object
-      required:
-      - '@context'
-      properties:
-        '@id':
-          type: string
-        '@type':
-          type: string
-          default: core:RealEstate
-        label:
-          type: string
-        core:hasRealEstateComponent:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:RealEstateComponent
-    core:RealEstateComponent:
-      type: object
-      required:
-      - '@context'
-      properties:
-        '@id':
-          type: string
-        '@type':
-          type: string
-          default: core:RealEstateComponent
-        label:
-          type: string
-        core:isPartOfRealEstate:
-          type: object
-          required:
-          - '@id'
-          properties:
-            '@id':
-              type: string
-            '@type':
-              type: string
-              default: core:RealEstate
+                default: core:Observation
     building:RoomType:
       type: object
       required:
@@ -1125,18 +1273,6 @@ components:
             '@type':
               type: string
               default: core:Building
-        core:containsMountedDevice:
-          type: array
-          items:
-            type: object
-            required:
-            - '@id'
-            properties:
-              '@id':
-                type: string
-              '@type':
-                type: string
-                default: core:Device
         core:hasSubBuildingComponent:
           type: array
           items:
@@ -1320,20 +1456,21 @@ paths:
       - actuationinterface
     post:
       summary: Create a new 'actuation:ActuationInterface' object.
-      parameters:
-      - name: entity
+      parameters: []
+      requestBody:
         description: New 'actuation:ActuationInterface' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/actuation%3aActuationInterface'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/actuation%3aActuationInterface'
       responses:
         500:
           description: Internal Server Error
@@ -1399,19 +1536,20 @@ paths:
         schema:
           type: string
         in: path
-      - name: entity
+      requestBody:
         description: Updated data for 'actuation:ActuationInterface' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/actuation%3aActuationInterface'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/actuation%3aActuationInterface'
       responses:
         400:
           description: Bad Request
@@ -1446,22 +1584,23 @@ paths:
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/actuation%3aActuationInterface'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/actuation%3aActuationInterface'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request
@@ -1512,12 +1651,6 @@ paths:
       - $ref: '#/components/parameters/pageParam'
       - $ref: '#/components/parameters/sizeParam'
       - $ref: '#/components/parameters/sortParam'
-      - name: device:devicePlacementContext
-        description: Filter value on property 'device:devicePlacementContext'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
       - name: core:hasSuperDevice
         description: Filter value on property 'core:hasSuperDevice'.
         schema:
@@ -1530,14 +1663,14 @@ paths:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: device:observedBy
-        description: Filter value on property 'device:observedBy'.
+      - name: core:quantityKind
+        description: Filter value on property 'core:quantityKind'.
         schema:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: core:deviceQuantityKind
-        description: Filter value on property 'core:deviceQuantityKind'.
+      - name: device:observedBy
+        description: Filter value on property 'device:observedBy'.
         schema:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
@@ -1626,12 +1759,6 @@ paths:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: core:deviceMeasurementUnit
-        description: Filter value on property 'core:deviceMeasurementUnit'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
       - name: core:hasSubDevice
         description: Filter value on property 'core:hasSubDevice'.
         schema:
@@ -1689,25 +1816,26 @@ paths:
                         - $ref: '#/components/schemas/device%3aActuator'
                         - type: object
                           required:
-                          - core:deviceQuantityKind
+                          - core:quantityKind
       tags:
       - actuator
     post:
       summary: Create a new 'device:Actuator' object.
-      parameters:
-      - name: entity
+      parameters: []
+      requestBody:
         description: New 'device:Actuator' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aActuator'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aActuator'
       responses:
         500:
           description: Internal Server Error
@@ -1728,7 +1856,7 @@ paths:
                 - $ref: '#/components/schemas/device%3aActuator'
                 - type: object
                   required:
-                  - core:deviceQuantityKind
+                  - core:quantityKind
       tags:
       - actuator
   /actuator/{id}:
@@ -1761,7 +1889,7 @@ paths:
                 - $ref: '#/components/schemas/device%3aActuator'
                 - type: object
                   required:
-                  - core:deviceQuantityKind
+                  - core:quantityKind
       tags:
       - actuator
     put:
@@ -1773,19 +1901,20 @@ paths:
         schema:
           type: string
         in: path
-      - name: entity
+      requestBody:
         description: Updated data for 'device:Actuator' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aActuator'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aActuator'
       responses:
         400:
           description: Bad Request
@@ -1808,7 +1937,7 @@ paths:
                 - $ref: '#/components/schemas/device%3aActuator'
                 - type: object
                   required:
-                  - core:deviceQuantityKind
+                  - core:quantityKind
       tags:
       - actuator
     patch:
@@ -1820,22 +1949,23 @@ paths:
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aActuator'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aActuator'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request
@@ -1858,7 +1988,7 @@ paths:
                 - $ref: '#/components/schemas/device%3aActuator'
                 - type: object
                   required:
-                  - core:deviceQuantityKind
+                  - core:quantityKind
       tags:
       - actuator
     delete:
@@ -1908,20 +2038,21 @@ paths:
       - devicefunctiontype
     post:
       summary: Create a new 'device:DeviceFunctionType' object.
-      parameters:
-      - name: entity
+      parameters: []
+      requestBody:
         description: New 'device:DeviceFunctionType' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aDeviceFunctionType'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aDeviceFunctionType'
       responses:
         500:
           description: Internal Server Error
@@ -1981,19 +2112,20 @@ paths:
         schema:
           type: string
         in: path
-      - name: entity
+      requestBody:
         description: Updated data for 'device:DeviceFunctionType' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aDeviceFunctionType'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aDeviceFunctionType'
       responses:
         400:
           description: Bad Request
@@ -2025,22 +2157,23 @@ paths:
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aDeviceFunctionType'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aDeviceFunctionType'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request
@@ -2110,20 +2243,21 @@ paths:
       - placementcontext
     post:
       summary: Create a new 'device:PlacementContext' object.
-      parameters:
-      - name: entity
+      parameters: []
+      requestBody:
         description: New 'device:PlacementContext' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aPlacementContext'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aPlacementContext'
       responses:
         500:
           description: Internal Server Error
@@ -2183,19 +2317,20 @@ paths:
         schema:
           type: string
         in: path
-      - name: entity
+      requestBody:
         description: Updated data for 'device:PlacementContext' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aPlacementContext'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aPlacementContext'
       responses:
         400:
           description: Bad Request
@@ -2227,22 +2362,23 @@ paths:
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aPlacementContext'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aPlacementContext'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request
@@ -2290,12 +2426,1756 @@ paths:
       - $ref: '#/components/parameters/pageParam'
       - $ref: '#/components/parameters/sizeParam'
       - $ref: '#/components/parameters/sortParam'
-      - name: device:devicePlacementContext
-        description: Filter value on property 'device:devicePlacementContext'.
+      - name: core:hasSuperDevice
+        description: Filter value on property 'core:hasSuperDevice'.
         schema:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
+      - name: core:isMountedInBuildingComponent
+        description: Filter value on property 'core:isMountedInBuildingComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:measurementUnit
+        description: Filter value on property 'core:measurementUnit'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:quantityKind
+        description: Filter value on property 'core:quantityKind'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:observesActuator
+        description: Filter value on property 'device:observesActuator'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasCommunicationsBus
+        description: Filter value on property 'device:hasCommunicationsBus'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasDeviceFunctionType
+        description: Filter value on property 'device:hasDeviceFunctionType'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasKNXDataPointType
+        description: Filter value on property 'device:hasKNXDataPointType'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusDataType
+        description: Filter value on property 'device:hasModbusDataType'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusFunctionCode
+        description: Filter value on property 'device:hasModbusFunctionCode'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasIPAddressPort
+        description: Filter value on property 'device:hasIPAddressPort'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasKNXDeviceId
+        description: Filter value on property 'device:hasKNXDeviceId'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasKNXDevicePort
+        description: Filter value on property 'device:hasKNXDevicePort'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasLoraDevEUI
+        description: Filter value on property 'device:hasLoraDevEUI'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusNodeId
+        description: Filter value on property 'device:hasModbusNodeId'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusRegister
+        description: Filter value on property 'device:hasModbusRegister'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasOffset
+        description: Filter value on property 'device:hasOffset'.
+        schema:
+          $ref: '#/components/schemas/NumberFilter'
+        style: deepObject
+        in: query
+      - name: device:hasScaleFactor
+        description: Filter value on property 'device:hasScaleFactor'.
+        schema:
+          $ref: '#/components/schemas/NumberFilter'
+        style: deepObject
+        in: query
+      - name: core:associatedWithEvent
+        description: Filter value on property 'core:associatedWithEvent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:hasSubDevice
+        description: Filter value on property 'core:hasSubDevice'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:servesBuilding
+        description: Filter value on property 'core:servesBuilding'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:servesBuildingComponent
+        description: Filter value on property 'core:servesBuildingComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:servesDevice
+        description: Filter value on property 'core:servesDevice'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'device:Sensor' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        allOf:
+                        - $ref: '#/components/schemas/device%3aSensor'
+                        - type: object
+                          required:
+                          - core:measurementUnit
+                          - core:quantityKind
+      tags:
+      - sensor
+    post:
+      summary: Create a new 'device:Sensor' object.
+      parameters: []
+      requestBody:
+        description: New 'device:Sensor' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aSensor'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/device%3aSensor'
+                - type: object
+                  required:
+                  - core:measurementUnit
+                  - core:quantityKind
+      tags:
+      - sensor
+  /sensor/{id}:
+    get:
+      summary: Get a specific 'device:Sensor' object.
+      parameters:
+      - name: id
+        description: Id of 'device:Sensor' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'device:Sensor' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'device:Sensor' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/device%3aSensor'
+                - type: object
+                  required:
+                  - core:measurementUnit
+                  - core:quantityKind
+      tags:
+      - sensor
+    put:
+      summary: Update an existing 'device:Sensor' entity.
+      parameters:
+      - name: id
+        description: Id of 'device:Sensor' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'device:Sensor' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aSensor'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'device:Sensor' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/device%3aSensor'
+                - type: object
+                  required:
+                  - core:measurementUnit
+                  - core:quantityKind
+      tags:
+      - sensor
+    patch:
+      summary: Update a single property on a specific 'device:Sensor' object.
+      parameters:
+      - name: id
+        description: Id of 'device:Sensor' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/device%3aSensor'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'device:Sensor' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/device%3aSensor'
+                - type: object
+                  required:
+                  - core:measurementUnit
+                  - core:quantityKind
+      tags:
+      - sensor
+    delete:
+      summary: Delete a 'device:Sensor' object.
+      parameters:
+      - name: id
+        description: Id of 'device:Sensor' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'device:Sensor' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'device:Sensor' entity was successfully deleted."
+      tags:
+      - sensor
+  /buildingcomponent:
+    get:
+      summary: Get 'core:BuildingComponent' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
+      - name: core:hasSuperBuildingComponent
+        description: Filter value on property 'core:hasSuperBuildingComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:isPartOfBuilding
+        description: Filter value on property 'core:isPartOfBuilding'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:hasSubBuildingComponent
+        description: Filter value on property 'core:hasSubBuildingComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'core:BuildingComponent' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/core%3aBuildingComponent'
+      tags:
+      - buildingcomponent
+    post:
+      summary: Create a new 'core:BuildingComponent' object.
+      parameters: []
+      requestBody:
+        description: New 'core:BuildingComponent' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aBuildingComponent'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aBuildingComponent'
+      tags:
+      - buildingcomponent
+  /buildingcomponent/{id}:
+    get:
+      summary: Get a specific 'core:BuildingComponent' object.
+      parameters:
+      - name: id
+        description: Id of 'core:BuildingComponent' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'core:BuildingComponent' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aBuildingComponent'
+      tags:
+      - buildingcomponent
+    put:
+      summary: Update an existing 'core:BuildingComponent' entity.
+      parameters:
+      - name: id
+        description: Id of 'core:BuildingComponent' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'core:BuildingComponent' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aBuildingComponent'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aBuildingComponent'
+      tags:
+      - buildingcomponent
+    patch:
+      summary: Update a single property on a specific 'core:BuildingComponent' object.
+      parameters:
+      - name: id
+        description: Id of 'core:BuildingComponent' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aBuildingComponent'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aBuildingComponent'
+      tags:
+      - buildingcomponent
+    delete:
+      summary: Delete a 'core:BuildingComponent' object.
+      parameters:
+      - name: id
+        description: Id of 'core:BuildingComponent' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'core:BuildingComponent' entity was successfully deleted."
+      tags:
+      - buildingcomponent
+  /device:
+    get:
+      summary: Get 'core:Device' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
+      - name: core:hasSuperDevice
+        description: Filter value on property 'core:hasSuperDevice'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:isMountedInBuildingComponent
+        description: Filter value on property 'core:isMountedInBuildingComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasCommunicationsBus
+        description: Filter value on property 'device:hasCommunicationsBus'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasDeviceFunctionType
+        description: Filter value on property 'device:hasDeviceFunctionType'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasKNXDataPointType
+        description: Filter value on property 'device:hasKNXDataPointType'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusDataType
+        description: Filter value on property 'device:hasModbusDataType'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusFunctionCode
+        description: Filter value on property 'device:hasModbusFunctionCode'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasIPAddressPort
+        description: Filter value on property 'device:hasIPAddressPort'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasKNXDeviceId
+        description: Filter value on property 'device:hasKNXDeviceId'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: device:hasKNXDevicePort
+        description: Filter value on property 'device:hasKNXDevicePort'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasLoraDevEUI
+        description: Filter value on property 'device:hasLoraDevEUI'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusNodeId
+        description: Filter value on property 'device:hasModbusNodeId'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasModbusRegister
+        description: Filter value on property 'device:hasModbusRegister'.
+        schema:
+          $ref: '#/components/schemas/IntegerFilter'
+        style: deepObject
+        in: query
+      - name: device:hasOffset
+        description: Filter value on property 'device:hasOffset'.
+        schema:
+          $ref: '#/components/schemas/NumberFilter'
+        style: deepObject
+        in: query
+      - name: device:hasScaleFactor
+        description: Filter value on property 'device:hasScaleFactor'.
+        schema:
+          $ref: '#/components/schemas/NumberFilter'
+        style: deepObject
+        in: query
+      - name: core:associatedWithEvent
+        description: Filter value on property 'core:associatedWithEvent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:hasSubDevice
+        description: Filter value on property 'core:hasSubDevice'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:servesBuilding
+        description: Filter value on property 'core:servesBuilding'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:servesBuildingComponent
+        description: Filter value on property 'core:servesBuildingComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      - name: core:servesDevice
+        description: Filter value on property 'core:servesDevice'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'core:Device' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/core%3aDevice'
+      tags:
+      - device
+    post:
+      summary: Create a new 'core:Device' object.
+      parameters: []
+      requestBody:
+        description: New 'core:Device' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aDevice'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aDevice'
+      tags:
+      - device
+  /device/{id}:
+    get:
+      summary: Get a specific 'core:Device' object.
+      parameters:
+      - name: id
+        description: Id of 'core:Device' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:Device' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'core:Device' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aDevice'
+      tags:
+      - device
+    put:
+      summary: Update an existing 'core:Device' entity.
+      parameters:
+      - name: id
+        description: Id of 'core:Device' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'core:Device' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aDevice'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:Device' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aDevice'
+      tags:
+      - device
+    patch:
+      summary: Update a single property on a specific 'core:Device' object.
+      parameters:
+      - name: id
+        description: Id of 'core:Device' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aDevice'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:Device' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aDevice'
+      tags:
+      - device
+    delete:
+      summary: Delete a 'core:Device' object.
+      parameters:
+      - name: id
+        description: Id of 'core:Device' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:Device' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'core:Device' entity was successfully deleted."
+      tags:
+      - device
+  /measurementunit:
+    get:
+      summary: Get 'core:MeasurementUnit' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'core:MeasurementUnit' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/core%3aMeasurementUnit'
+      tags:
+      - measurementunit
+    post:
+      summary: Create a new 'core:MeasurementUnit' object.
+      parameters: []
+      requestBody:
+        description: New 'core:MeasurementUnit' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aMeasurementUnit'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aMeasurementUnit'
+      tags:
+      - measurementunit
+  /measurementunit/{id}:
+    get:
+      summary: Get a specific 'core:MeasurementUnit' object.
+      parameters:
+      - name: id
+        description: Id of 'core:MeasurementUnit' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'core:MeasurementUnit' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aMeasurementUnit'
+      tags:
+      - measurementunit
+    put:
+      summary: Update an existing 'core:MeasurementUnit' entity.
+      parameters:
+      - name: id
+        description: Id of 'core:MeasurementUnit' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'core:MeasurementUnit' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aMeasurementUnit'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aMeasurementUnit'
+      tags:
+      - measurementunit
+    patch:
+      summary: Update a single property on a specific 'core:MeasurementUnit' object.
+      parameters:
+      - name: id
+        description: Id of 'core:MeasurementUnit' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aMeasurementUnit'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aMeasurementUnit'
+      tags:
+      - measurementunit
+    delete:
+      summary: Delete a 'core:MeasurementUnit' object.
+      parameters:
+      - name: id
+        description: Id of 'core:MeasurementUnit' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'core:MeasurementUnit' entity was successfully deleted."
+      tags:
+      - measurementunit
+  /quantitykind:
+    get:
+      summary: Get 'core:QuantityKind' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
+      - name: core:measurementUnit
+        description: Filter value on property 'core:measurementUnit'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'core:QuantityKind' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/core%3aQuantityKind'
+      tags:
+      - quantitykind
+    post:
+      summary: Create a new 'core:QuantityKind' object.
+      parameters: []
+      requestBody:
+        description: New 'core:QuantityKind' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aQuantityKind'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aQuantityKind'
+      tags:
+      - quantitykind
+  /quantitykind/{id}:
+    get:
+      summary: Get a specific 'core:QuantityKind' object.
+      parameters:
+      - name: id
+        description: Id of 'core:QuantityKind' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:QuantityKind' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'core:QuantityKind' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aQuantityKind'
+      tags:
+      - quantitykind
+    put:
+      summary: Update an existing 'core:QuantityKind' entity.
+      parameters:
+      - name: id
+        description: Id of 'core:QuantityKind' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'core:QuantityKind' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aQuantityKind'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:QuantityKind' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aQuantityKind'
+      tags:
+      - quantitykind
+    patch:
+      summary: Update a single property on a specific 'core:QuantityKind' object.
+      parameters:
+      - name: id
+        description: Id of 'core:QuantityKind' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aQuantityKind'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:QuantityKind' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aQuantityKind'
+      tags:
+      - quantitykind
+    delete:
+      summary: Delete a 'core:QuantityKind' object.
+      parameters:
+      - name: id
+        description: Id of 'core:QuantityKind' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:QuantityKind' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'core:QuantityKind' entity was successfully deleted."
+      tags:
+      - quantitykind
+  /realestate:
+    get:
+      summary: Get 'core:RealEstate' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
+      - name: core:hasRealEstateComponent
+        description: Filter value on property 'core:hasRealEstateComponent'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'core:RealEstate' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/core%3aRealEstate'
+      tags:
+      - realestate
+    post:
+      summary: Create a new 'core:RealEstate' object.
+      parameters: []
+      requestBody:
+        description: New 'core:RealEstate' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aRealEstate'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstate'
+      tags:
+      - realestate
+  /realestate/{id}:
+    get:
+      summary: Get a specific 'core:RealEstate' object.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstate' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:RealEstate' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'core:RealEstate' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstate'
+      tags:
+      - realestate
+    put:
+      summary: Update an existing 'core:RealEstate' entity.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstate' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'core:RealEstate' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aRealEstate'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:RealEstate' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstate'
+      tags:
+      - realestate
+    patch:
+      summary: Update a single property on a specific 'core:RealEstate' object.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstate' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aRealEstate'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:RealEstate' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstate'
+      tags:
+      - realestate
+    delete:
+      summary: Delete a 'core:RealEstate' object.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstate' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:RealEstate' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'core:RealEstate' entity was successfully deleted."
+      tags:
+      - realestate
+  /realestatecomponent:
+    get:
+      summary: Get 'core:RealEstateComponent' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
+      - name: core:isPartOfRealEstate
+        description: Filter value on property 'core:isPartOfRealEstate'.
+        schema:
+          $ref: '#/components/schemas/StringFilter'
+        style: deepObject
+        in: query
+      responses:
+        400:
+          description: Bad Request
+        500:
+          description: Internal Server Error
+        200:
+          description: An array of 'core:RealEstateComponent' objects.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HydraCollectionWrapper'
+                - type: object
+                  properties:
+                    hydra:member:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/core%3aRealEstateComponent'
+      tags:
+      - realestatecomponent
+    post:
+      summary: Create a new 'core:RealEstateComponent' object.
+      parameters: []
+      requestBody:
+        description: New 'core:RealEstateComponent' entity that is to be added.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aRealEstateComponent'
+      responses:
+        500:
+          description: Internal Server Error
+        400:
+          description: Bad Request
+        201:
+          description: Entity was successfully created (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstateComponent'
+      tags:
+      - realestatecomponent
+  /realestatecomponent/{id}:
+    get:
+      summary: Get a specific 'core:RealEstateComponent' object.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstateComponent' to return.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: A 'core:RealEstateComponent' object.
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstateComponent'
+      tags:
+      - realestatecomponent
+    put:
+      summary: Update an existing 'core:RealEstateComponent' entity.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstateComponent' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: Updated data for 'core:RealEstateComponent' entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aRealEstateComponent'
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstateComponent'
+      tags:
+      - realestatecomponent
+    patch:
+      summary: Update a single property on a specific 'core:RealEstateComponent' object.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstateComponent' to update.
+        required: true
+        schema:
+          type: string
+        in: path
+      requestBody:
+        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aRealEstateComponent'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
+      responses:
+        400:
+          description: Bad Request
+        404:
+          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: Entity was updated successfully (new representation returned).
+          content:
+            application/jsonld:
+              schema:
+                allOf:
+                - type: object
+                  required:
+                  - '@context'
+                  properties:
+                    '@context':
+                      $ref: '#/components/schemas/Context'
+                - $ref: '#/components/schemas/core%3aRealEstateComponent'
+      tags:
+      - realestatecomponent
+    delete:
+      summary: Delete a 'core:RealEstateComponent' object.
+      parameters:
+      - name: id
+        description: Id of 'core:RealEstateComponent' to delete.
+        required: true
+        schema:
+          type: string
+        in: path
+      responses:
+        404:
+          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
+        500:
+          description: Internal Server Error
+        200:
+          description: "'core:RealEstateComponent' entity was successfully deleted."
+      tags:
+      - realestatecomponent
+  /sensors:
+    get:
+      summary: Get 'core:Sensor' entities.
+      parameters:
+      - $ref: '#/components/parameters/pageParam'
+      - $ref: '#/components/parameters/sizeParam'
+      - $ref: '#/components/parameters/sortParam'
       - name: core:hasSuperDevice
         description: Filter value on property 'core:hasSuperDevice'.
         schema:
@@ -2314,14 +4194,14 @@ paths:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: core:deviceMeasurementUnit
-        description: Filter value on property 'core:deviceMeasurementUnit'.
+      - name: core:measurementUnit
+        description: Filter value on property 'core:measurementUnit'.
         schema:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: core:deviceQuantityKind
-        description: Filter value on property 'core:deviceQuantityKind'.
+      - name: core:quantityKind
+        description: Filter value on property 'core:quantityKind'.
         schema:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
@@ -2440,8 +4320,8 @@ paths:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: device:generatedObservation
-        description: Filter value on property 'device:generatedObservation'.
+      - name: core:generatedObservation
+        description: Filter value on property 'core:generatedObservation'.
         schema:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
@@ -2452,7 +4332,7 @@ paths:
         500:
           description: Internal Server Error
         200:
-          description: An array of 'device:Sensor' objects.
+          description: An array of 'core:Sensor' objects.
           content:
             application/jsonld:
               schema:
@@ -2464,29 +4344,30 @@ paths:
                       type: array
                       items:
                         allOf:
-                        - $ref: '#/components/schemas/device%3aSensor'
+                        - $ref: '#/components/schemas/core%3aSensor'
                         - type: object
                           required:
-                          - core:deviceMeasurementUnit
-                          - core:deviceQuantityKind
+                          - core:measurementUnit
+                          - core:quantityKind
       tags:
-      - sensor
+      - sensors
     post:
-      summary: Create a new 'device:Sensor' object.
-      parameters:
-      - name: entity
-        description: New 'device:Sensor' entity that is to be added.
+      summary: Create a new 'core:Sensor' object.
+      parameters: []
+      requestBody:
+        description: New 'core:Sensor' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aSensor'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aSensor'
       responses:
         500:
           description: Internal Server Error
@@ -2504,30 +4385,30 @@ paths:
                   properties:
                     '@context':
                       $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/device%3aSensor'
+                - $ref: '#/components/schemas/core%3aSensor'
                 - type: object
                   required:
-                  - core:deviceMeasurementUnit
-                  - core:deviceQuantityKind
+                  - core:measurementUnit
+                  - core:quantityKind
       tags:
-      - sensor
-  /sensor/{id}:
+      - sensors
+  /sensors/{id}:
     get:
-      summary: Get a specific 'device:Sensor' object.
+      summary: Get a specific 'core:Sensor' object.
       parameters:
       - name: id
-        description: Id of 'device:Sensor' to return.
+        description: Id of 'core:Sensor' to return.
         required: true
         schema:
           type: string
         in: path
       responses:
         404:
-          description: An object of type 'device:Sensor' with the specified ID was not found.
+          description: An object of type 'core:Sensor' with the specified ID was not found.
         500:
           description: Internal Server Error
         200:
-          description: A 'device:Sensor' object.
+          description: A 'core:Sensor' object.
           content:
             application/jsonld:
               schema:
@@ -2538,40 +4419,41 @@ paths:
                   properties:
                     '@context':
                       $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/device%3aSensor'
+                - $ref: '#/components/schemas/core%3aSensor'
                 - type: object
                   required:
-                  - core:deviceMeasurementUnit
-                  - core:deviceQuantityKind
+                  - core:measurementUnit
+                  - core:quantityKind
       tags:
-      - sensor
+      - sensors
     put:
-      summary: Update an existing 'device:Sensor' entity.
+      summary: Update an existing 'core:Sensor' entity.
       parameters:
       - name: id
-        description: Id of 'device:Sensor' to update.
+        description: Id of 'core:Sensor' to update.
         required: true
         schema:
           type: string
         in: path
-      - name: entity
-        description: Updated data for 'device:Sensor' entity.
+      requestBody:
+        description: Updated data for 'core:Sensor' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aSensor'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aSensor'
       responses:
         400:
           description: Bad Request
         404:
-          description: An object of type 'device:Sensor' with the specified ID was not found.
+          description: An object of type 'core:Sensor' with the specified ID was not found.
         500:
           description: Internal Server Error
         200:
@@ -2586,43 +4468,44 @@ paths:
                   properties:
                     '@context':
                       $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/device%3aSensor'
+                - $ref: '#/components/schemas/core%3aSensor'
                 - type: object
                   required:
-                  - core:deviceMeasurementUnit
-                  - core:deviceQuantityKind
+                  - core:measurementUnit
+                  - core:quantityKind
       tags:
-      - sensor
+      - sensors
     patch:
-      summary: Update a single property on a specific 'device:Sensor' object.
+      summary: Update a single property on a specific 'core:Sensor' object.
       parameters:
       - name: id
-        description: Id of 'device:Sensor' to update.
+        description: Id of 'core:Sensor' to update.
         required: true
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/device%3aSensor'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/core%3aSensor'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request
         404:
-          description: An object of type 'device:Sensor' with the specified ID was not found.
+          description: An object of type 'core:Sensor' with the specified ID was not found.
         500:
           description: Internal Server Error
         200:
@@ -2637,1423 +4520,31 @@ paths:
                   properties:
                     '@context':
                       $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/device%3aSensor'
+                - $ref: '#/components/schemas/core%3aSensor'
                 - type: object
                   required:
-                  - core:deviceMeasurementUnit
-                  - core:deviceQuantityKind
+                  - core:measurementUnit
+                  - core:quantityKind
       tags:
-      - sensor
+      - sensors
     delete:
-      summary: Delete a 'device:Sensor' object.
+      summary: Delete a 'core:Sensor' object.
       parameters:
       - name: id
-        description: Id of 'device:Sensor' to delete.
+        description: Id of 'core:Sensor' to delete.
         required: true
         schema:
           type: string
         in: path
       responses:
         404:
-          description: An object of type 'device:Sensor' with the specified ID was not found.
+          description: An object of type 'core:Sensor' with the specified ID was not found.
         500:
           description: Internal Server Error
         200:
-          description: "'device:Sensor' entity was successfully deleted."
+          description: "'core:Sensor' entity was successfully deleted."
       tags:
-      - sensor
-  /buildingcomponent:
-    get:
-      summary: Get 'core:BuildingComponent' entities.
-      parameters:
-      - $ref: '#/components/parameters/pageParam'
-      - $ref: '#/components/parameters/sizeParam'
-      - $ref: '#/components/parameters/sortParam'
-      - name: core:hasSuperBuildingComponent
-        description: Filter value on property 'core:hasSuperBuildingComponent'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:isPartOfBuilding
-        description: Filter value on property 'core:isPartOfBuilding'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:containsMountedDevice
-        description: Filter value on property 'core:containsMountedDevice'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:hasSubBuildingComponent
-        description: Filter value on property 'core:hasSubBuildingComponent'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      responses:
-        400:
-          description: Bad Request
-        500:
-          description: Internal Server Error
-        200:
-          description: An array of 'core:BuildingComponent' objects.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/HydraCollectionWrapper'
-                - type: object
-                  properties:
-                    hydra:member:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/core%3aBuildingComponent'
-      tags:
-      - buildingcomponent
-    post:
-      summary: Create a new 'core:BuildingComponent' object.
-      parameters:
-      - name: entity
-        description: New 'core:BuildingComponent' entity that is to be added.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aBuildingComponent'
-        in: header
-      responses:
-        500:
-          description: Internal Server Error
-        400:
-          description: Bad Request
-        201:
-          description: Entity was successfully created (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aBuildingComponent'
-      tags:
-      - buildingcomponent
-  /buildingcomponent/{id}:
-    get:
-      summary: Get a specific 'core:BuildingComponent' object.
-      parameters:
-      - name: id
-        description: Id of 'core:BuildingComponent' to return.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: A 'core:BuildingComponent' object.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aBuildingComponent'
-      tags:
-      - buildingcomponent
-    put:
-      summary: Update an existing 'core:BuildingComponent' entity.
-      parameters:
-      - name: id
-        description: Id of 'core:BuildingComponent' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: entity
-        description: Updated data for 'core:BuildingComponent' entity.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aBuildingComponent'
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aBuildingComponent'
-      tags:
-      - buildingcomponent
-    patch:
-      summary: Update a single property on a specific 'core:BuildingComponent' object.
-      parameters:
-      - name: id
-        description: Id of 'core:BuildingComponent' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: patch
-        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aBuildingComponent'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aBuildingComponent'
-      tags:
-      - buildingcomponent
-    delete:
-      summary: Delete a 'core:BuildingComponent' object.
-      parameters:
-      - name: id
-        description: Id of 'core:BuildingComponent' to delete.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:BuildingComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: "'core:BuildingComponent' entity was successfully deleted."
-      tags:
-      - buildingcomponent
-  /device:
-    get:
-      summary: Get 'core:Device' entities.
-      parameters:
-      - $ref: '#/components/parameters/pageParam'
-      - $ref: '#/components/parameters/sizeParam'
-      - $ref: '#/components/parameters/sortParam'
-      - name: device:devicePlacementContext
-        description: Filter value on property 'device:devicePlacementContext'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:hasSuperDevice
-        description: Filter value on property 'core:hasSuperDevice'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:isMountedInBuildingComponent
-        description: Filter value on property 'core:isMountedInBuildingComponent'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasCommunicationsBus
-        description: Filter value on property 'device:hasCommunicationsBus'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasDeviceFunctionType
-        description: Filter value on property 'device:hasDeviceFunctionType'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasKNXDataPointType
-        description: Filter value on property 'device:hasKNXDataPointType'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasModbusDataType
-        description: Filter value on property 'device:hasModbusDataType'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasModbusFunctionCode
-        description: Filter value on property 'device:hasModbusFunctionCode'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasIPAddressPort
-        description: Filter value on property 'device:hasIPAddressPort'.
-        schema:
-          $ref: '#/components/schemas/IntegerFilter'
-        style: deepObject
-        in: query
-      - name: device:hasKNXDeviceId
-        description: Filter value on property 'device:hasKNXDeviceId'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: device:hasKNXDevicePort
-        description: Filter value on property 'device:hasKNXDevicePort'.
-        schema:
-          $ref: '#/components/schemas/IntegerFilter'
-        style: deepObject
-        in: query
-      - name: device:hasLoraDevEUI
-        description: Filter value on property 'device:hasLoraDevEUI'.
-        schema:
-          $ref: '#/components/schemas/IntegerFilter'
-        style: deepObject
-        in: query
-      - name: device:hasModbusNodeId
-        description: Filter value on property 'device:hasModbusNodeId'.
-        schema:
-          $ref: '#/components/schemas/IntegerFilter'
-        style: deepObject
-        in: query
-      - name: device:hasModbusRegister
-        description: Filter value on property 'device:hasModbusRegister'.
-        schema:
-          $ref: '#/components/schemas/IntegerFilter'
-        style: deepObject
-        in: query
-      - name: device:hasOffset
-        description: Filter value on property 'device:hasOffset'.
-        schema:
-          $ref: '#/components/schemas/NumberFilter'
-        style: deepObject
-        in: query
-      - name: device:hasScaleFactor
-        description: Filter value on property 'device:hasScaleFactor'.
-        schema:
-          $ref: '#/components/schemas/NumberFilter'
-        style: deepObject
-        in: query
-      - name: core:associatedWithEvent
-        description: Filter value on property 'core:associatedWithEvent'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:deviceMeasurementUnit
-        description: Filter value on property 'core:deviceMeasurementUnit'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:deviceQuantityKind
-        description: Filter value on property 'core:deviceQuantityKind'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:hasSubDevice
-        description: Filter value on property 'core:hasSubDevice'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:servesBuilding
-        description: Filter value on property 'core:servesBuilding'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:servesBuildingComponent
-        description: Filter value on property 'core:servesBuildingComponent'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      - name: core:servesDevice
-        description: Filter value on property 'core:servesDevice'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      responses:
-        400:
-          description: Bad Request
-        500:
-          description: Internal Server Error
-        200:
-          description: An array of 'core:Device' objects.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/HydraCollectionWrapper'
-                - type: object
-                  properties:
-                    hydra:member:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/core%3aDevice'
-      tags:
-      - device
-    post:
-      summary: Create a new 'core:Device' object.
-      parameters:
-      - name: entity
-        description: New 'core:Device' entity that is to be added.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aDevice'
-        in: header
-      responses:
-        500:
-          description: Internal Server Error
-        400:
-          description: Bad Request
-        201:
-          description: Entity was successfully created (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aDevice'
-      tags:
-      - device
-  /device/{id}:
-    get:
-      summary: Get a specific 'core:Device' object.
-      parameters:
-      - name: id
-        description: Id of 'core:Device' to return.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:Device' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: A 'core:Device' object.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aDevice'
-      tags:
-      - device
-    put:
-      summary: Update an existing 'core:Device' entity.
-      parameters:
-      - name: id
-        description: Id of 'core:Device' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: entity
-        description: Updated data for 'core:Device' entity.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aDevice'
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:Device' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aDevice'
-      tags:
-      - device
-    patch:
-      summary: Update a single property on a specific 'core:Device' object.
-      parameters:
-      - name: id
-        description: Id of 'core:Device' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: patch
-        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aDevice'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:Device' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aDevice'
-      tags:
-      - device
-    delete:
-      summary: Delete a 'core:Device' object.
-      parameters:
-      - name: id
-        description: Id of 'core:Device' to delete.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:Device' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: "'core:Device' entity was successfully deleted."
-      tags:
-      - device
-  /measurementunit:
-    get:
-      summary: Get 'core:MeasurementUnit' entities.
-      parameters:
-      - $ref: '#/components/parameters/pageParam'
-      - $ref: '#/components/parameters/sizeParam'
-      - $ref: '#/components/parameters/sortParam'
-      responses:
-        400:
-          description: Bad Request
-        500:
-          description: Internal Server Error
-        200:
-          description: An array of 'core:MeasurementUnit' objects.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/HydraCollectionWrapper'
-                - type: object
-                  properties:
-                    hydra:member:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/core%3aMeasurementUnit'
-      tags:
-      - measurementunit
-    post:
-      summary: Create a new 'core:MeasurementUnit' object.
-      parameters:
-      - name: entity
-        description: New 'core:MeasurementUnit' entity that is to be added.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aMeasurementUnit'
-        in: header
-      responses:
-        500:
-          description: Internal Server Error
-        400:
-          description: Bad Request
-        201:
-          description: Entity was successfully created (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aMeasurementUnit'
-      tags:
-      - measurementunit
-  /measurementunit/{id}:
-    get:
-      summary: Get a specific 'core:MeasurementUnit' object.
-      parameters:
-      - name: id
-        description: Id of 'core:MeasurementUnit' to return.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: A 'core:MeasurementUnit' object.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aMeasurementUnit'
-      tags:
-      - measurementunit
-    put:
-      summary: Update an existing 'core:MeasurementUnit' entity.
-      parameters:
-      - name: id
-        description: Id of 'core:MeasurementUnit' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: entity
-        description: Updated data for 'core:MeasurementUnit' entity.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aMeasurementUnit'
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aMeasurementUnit'
-      tags:
-      - measurementunit
-    patch:
-      summary: Update a single property on a specific 'core:MeasurementUnit' object.
-      parameters:
-      - name: id
-        description: Id of 'core:MeasurementUnit' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: patch
-        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aMeasurementUnit'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aMeasurementUnit'
-      tags:
-      - measurementunit
-    delete:
-      summary: Delete a 'core:MeasurementUnit' object.
-      parameters:
-      - name: id
-        description: Id of 'core:MeasurementUnit' to delete.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:MeasurementUnit' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: "'core:MeasurementUnit' entity was successfully deleted."
-      tags:
-      - measurementunit
-  /quantitykind:
-    get:
-      summary: Get 'core:QuantityKind' entities.
-      parameters:
-      - $ref: '#/components/parameters/pageParam'
-      - $ref: '#/components/parameters/sizeParam'
-      - $ref: '#/components/parameters/sortParam'
-      - name: core:qkMeasurementUnit
-        description: Filter value on property 'core:qkMeasurementUnit'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      responses:
-        400:
-          description: Bad Request
-        500:
-          description: Internal Server Error
-        200:
-          description: An array of 'core:QuantityKind' objects.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/HydraCollectionWrapper'
-                - type: object
-                  properties:
-                    hydra:member:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/core%3aQuantityKind'
-      tags:
-      - quantitykind
-    post:
-      summary: Create a new 'core:QuantityKind' object.
-      parameters:
-      - name: entity
-        description: New 'core:QuantityKind' entity that is to be added.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aQuantityKind'
-        in: header
-      responses:
-        500:
-          description: Internal Server Error
-        400:
-          description: Bad Request
-        201:
-          description: Entity was successfully created (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aQuantityKind'
-      tags:
-      - quantitykind
-  /quantitykind/{id}:
-    get:
-      summary: Get a specific 'core:QuantityKind' object.
-      parameters:
-      - name: id
-        description: Id of 'core:QuantityKind' to return.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:QuantityKind' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: A 'core:QuantityKind' object.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aQuantityKind'
-      tags:
-      - quantitykind
-    put:
-      summary: Update an existing 'core:QuantityKind' entity.
-      parameters:
-      - name: id
-        description: Id of 'core:QuantityKind' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: entity
-        description: Updated data for 'core:QuantityKind' entity.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aQuantityKind'
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:QuantityKind' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aQuantityKind'
-      tags:
-      - quantitykind
-    patch:
-      summary: Update a single property on a specific 'core:QuantityKind' object.
-      parameters:
-      - name: id
-        description: Id of 'core:QuantityKind' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: patch
-        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aQuantityKind'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:QuantityKind' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aQuantityKind'
-      tags:
-      - quantitykind
-    delete:
-      summary: Delete a 'core:QuantityKind' object.
-      parameters:
-      - name: id
-        description: Id of 'core:QuantityKind' to delete.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:QuantityKind' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: "'core:QuantityKind' entity was successfully deleted."
-      tags:
-      - quantitykind
-  /realestate:
-    get:
-      summary: Get 'core:RealEstate' entities.
-      parameters:
-      - $ref: '#/components/parameters/pageParam'
-      - $ref: '#/components/parameters/sizeParam'
-      - $ref: '#/components/parameters/sortParam'
-      - name: core:hasRealEstateComponent
-        description: Filter value on property 'core:hasRealEstateComponent'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      responses:
-        400:
-          description: Bad Request
-        500:
-          description: Internal Server Error
-        200:
-          description: An array of 'core:RealEstate' objects.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/HydraCollectionWrapper'
-                - type: object
-                  properties:
-                    hydra:member:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/core%3aRealEstate'
-      tags:
-      - realestate
-    post:
-      summary: Create a new 'core:RealEstate' object.
-      parameters:
-      - name: entity
-        description: New 'core:RealEstate' entity that is to be added.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aRealEstate'
-        in: header
-      responses:
-        500:
-          description: Internal Server Error
-        400:
-          description: Bad Request
-        201:
-          description: Entity was successfully created (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstate'
-      tags:
-      - realestate
-  /realestate/{id}:
-    get:
-      summary: Get a specific 'core:RealEstate' object.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstate' to return.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:RealEstate' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: A 'core:RealEstate' object.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstate'
-      tags:
-      - realestate
-    put:
-      summary: Update an existing 'core:RealEstate' entity.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstate' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: entity
-        description: Updated data for 'core:RealEstate' entity.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aRealEstate'
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:RealEstate' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstate'
-      tags:
-      - realestate
-    patch:
-      summary: Update a single property on a specific 'core:RealEstate' object.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstate' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: patch
-        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aRealEstate'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:RealEstate' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstate'
-      tags:
-      - realestate
-    delete:
-      summary: Delete a 'core:RealEstate' object.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstate' to delete.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:RealEstate' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: "'core:RealEstate' entity was successfully deleted."
-      tags:
-      - realestate
-  /realestatecomponent:
-    get:
-      summary: Get 'core:RealEstateComponent' entities.
-      parameters:
-      - $ref: '#/components/parameters/pageParam'
-      - $ref: '#/components/parameters/sizeParam'
-      - $ref: '#/components/parameters/sortParam'
-      - name: core:isPartOfRealEstate
-        description: Filter value on property 'core:isPartOfRealEstate'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
-      responses:
-        400:
-          description: Bad Request
-        500:
-          description: Internal Server Error
-        200:
-          description: An array of 'core:RealEstateComponent' objects.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/HydraCollectionWrapper'
-                - type: object
-                  properties:
-                    hydra:member:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/core%3aRealEstateComponent'
-      tags:
-      - realestatecomponent
-    post:
-      summary: Create a new 'core:RealEstateComponent' object.
-      parameters:
-      - name: entity
-        description: New 'core:RealEstateComponent' entity that is to be added.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aRealEstateComponent'
-        in: header
-      responses:
-        500:
-          description: Internal Server Error
-        400:
-          description: Bad Request
-        201:
-          description: Entity was successfully created (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstateComponent'
-      tags:
-      - realestatecomponent
-  /realestatecomponent/{id}:
-    get:
-      summary: Get a specific 'core:RealEstateComponent' object.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstateComponent' to return.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: A 'core:RealEstateComponent' object.
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstateComponent'
-      tags:
-      - realestatecomponent
-    put:
-      summary: Update an existing 'core:RealEstateComponent' entity.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstateComponent' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: entity
-        description: Updated data for 'core:RealEstateComponent' entity.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aRealEstateComponent'
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstateComponent'
-      tags:
-      - realestatecomponent
-    patch:
-      summary: Update a single property on a specific 'core:RealEstateComponent' object.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstateComponent' to update.
-        required: true
-        schema:
-          type: string
-        in: path
-      - name: patch
-        description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
-        required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/core%3aRealEstateComponent'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
-      responses:
-        400:
-          description: Bad Request
-        404:
-          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: Entity was updated successfully (new representation returned).
-          content:
-            application/jsonld:
-              schema:
-                allOf:
-                - type: object
-                  required:
-                  - '@context'
-                  properties:
-                    '@context':
-                      $ref: '#/components/schemas/Context'
-                - $ref: '#/components/schemas/core%3aRealEstateComponent'
-      tags:
-      - realestatecomponent
-    delete:
-      summary: Delete a 'core:RealEstateComponent' object.
-      parameters:
-      - name: id
-        description: Id of 'core:RealEstateComponent' to delete.
-        required: true
-        schema:
-          type: string
-        in: path
-      responses:
-        404:
-          description: An object of type 'core:RealEstateComponent' with the specified ID was not found.
-        500:
-          description: Internal Server Error
-        200:
-          description: "'core:RealEstateComponent' entity was successfully deleted."
-      tags:
-      - realestatecomponent
+      - sensors
   /roomtype:
     get:
       summary: Get 'building:RoomType' entities.
@@ -4083,20 +4574,21 @@ paths:
       - roomtype
     post:
       summary: Create a new 'building:RoomType' object.
-      parameters:
-      - name: entity
+      parameters: []
+      requestBody:
         description: New 'building:RoomType' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/building%3aRoomType'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/building%3aRoomType'
       responses:
         500:
           description: Internal Server Error
@@ -4156,19 +4648,20 @@ paths:
         schema:
           type: string
         in: path
-      - name: entity
+      requestBody:
         description: Updated data for 'building:RoomType' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/building%3aRoomType'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/building%3aRoomType'
       responses:
         400:
           description: Bad Request
@@ -4200,22 +4693,23 @@ paths:
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/building%3aRoomType'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/building%3aRoomType'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request
@@ -4275,12 +4769,6 @@ paths:
           $ref: '#/components/schemas/StringFilter'
         style: deepObject
         in: query
-      - name: core:containsMountedDevice
-        description: Filter value on property 'core:containsMountedDevice'.
-        schema:
-          $ref: '#/components/schemas/StringFilter'
-        style: deepObject
-        in: query
       - name: core:hasSubBuildingComponent
         description: Filter value on property 'core:hasSubBuildingComponent'.
         schema:
@@ -4309,20 +4797,21 @@ paths:
       - storey
     post:
       summary: Create a new 'building:Storey' object.
-      parameters:
-      - name: entity
+      parameters: []
+      requestBody:
         description: New 'building:Storey' entity that is to be added.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/building%3aStorey'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/building%3aStorey'
       responses:
         500:
           description: Internal Server Error
@@ -4382,19 +4871,20 @@ paths:
         schema:
           type: string
         in: path
-      - name: entity
+      requestBody:
         description: Updated data for 'building:Storey' entity.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/building%3aStorey'
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/building%3aStorey'
       responses:
         400:
           description: Bad Request
@@ -4426,22 +4916,23 @@ paths:
         schema:
           type: string
         in: path
-      - name: patch
+      requestBody:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
-        schema:
-          allOf:
-          - type: object
-            required:
-            - '@context'
-            properties:
-              '@context':
-                $ref: '#/components/schemas/Context'
-          - $ref: '#/components/schemas/building%3aStorey'
-          - type: object
-            maxProperties: 2
-            minProperties: 2
-        in: header
+        content:
+          application/json:
+            schema:
+              allOf:
+              - type: object
+                required:
+                - '@context'
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+              - $ref: '#/components/schemas/building%3aStorey'
+              - type: object
+                maxProperties: 2
+                minProperties: 2
       responses:
         400:
           description: Bad Request

--- a/api/REST/rec-full-v3.1.2.yaml
+++ b/api/REST/rec-full-v3.1.2.yaml
@@ -1438,7 +1438,7 @@ paths:
         200:
           description: An array of 'actuation:ActuationInterface' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -1461,7 +1461,7 @@ paths:
         description: New 'actuation:ActuationInterface' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -1479,7 +1479,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1512,7 +1512,7 @@ paths:
         200:
           description: A 'actuation:ActuationInterface' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1540,7 +1540,7 @@ paths:
         description: Updated data for 'actuation:ActuationInterface' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -1560,7 +1560,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1588,7 +1588,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -1611,7 +1611,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1803,7 +1803,7 @@ paths:
         200:
           description: An array of 'device:Actuator' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -1826,7 +1826,7 @@ paths:
         description: New 'device:Actuator' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -1844,7 +1844,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1877,7 +1877,7 @@ paths:
         200:
           description: A 'device:Actuator' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1905,7 +1905,7 @@ paths:
         description: Updated data for 'device:Actuator' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -1925,7 +1925,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -1953,7 +1953,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -1976,7 +1976,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2024,7 +2024,7 @@ paths:
         200:
           description: An array of 'device:DeviceFunctionType' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -2043,7 +2043,7 @@ paths:
         description: New 'device:DeviceFunctionType' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2061,7 +2061,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2091,7 +2091,7 @@ paths:
         200:
           description: A 'device:DeviceFunctionType' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2116,7 +2116,7 @@ paths:
         description: Updated data for 'device:DeviceFunctionType' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2136,7 +2136,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2161,7 +2161,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2184,7 +2184,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2229,7 +2229,7 @@ paths:
         200:
           description: An array of 'device:PlacementContext' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -2248,7 +2248,7 @@ paths:
         description: New 'device:PlacementContext' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2266,7 +2266,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2296,7 +2296,7 @@ paths:
         200:
           description: A 'device:PlacementContext' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2321,7 +2321,7 @@ paths:
         description: Updated data for 'device:PlacementContext' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2341,7 +2341,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2366,7 +2366,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2389,7 +2389,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2572,7 +2572,7 @@ paths:
         200:
           description: An array of 'device:Sensor' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -2596,7 +2596,7 @@ paths:
         description: New 'device:Sensor' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2614,7 +2614,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2648,7 +2648,7 @@ paths:
         200:
           description: A 'device:Sensor' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2677,7 +2677,7 @@ paths:
         description: Updated data for 'device:Sensor' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2697,7 +2697,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2726,7 +2726,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2749,7 +2749,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2816,7 +2816,7 @@ paths:
         200:
           description: An array of 'core:BuildingComponent' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -2835,7 +2835,7 @@ paths:
         description: New 'core:BuildingComponent' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2853,7 +2853,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2883,7 +2883,7 @@ paths:
         200:
           description: A 'core:BuildingComponent' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2908,7 +2908,7 @@ paths:
         description: Updated data for 'core:BuildingComponent' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2928,7 +2928,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -2953,7 +2953,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -2976,7 +2976,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3141,7 +3141,7 @@ paths:
         200:
           description: An array of 'core:Device' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -3160,7 +3160,7 @@ paths:
         description: New 'core:Device' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3178,7 +3178,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3208,7 +3208,7 @@ paths:
         200:
           description: A 'core:Device' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3233,7 +3233,7 @@ paths:
         description: Updated data for 'core:Device' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3253,7 +3253,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3278,7 +3278,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3301,7 +3301,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3346,7 +3346,7 @@ paths:
         200:
           description: An array of 'core:MeasurementUnit' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -3365,7 +3365,7 @@ paths:
         description: New 'core:MeasurementUnit' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3383,7 +3383,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3413,7 +3413,7 @@ paths:
         200:
           description: A 'core:MeasurementUnit' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3438,7 +3438,7 @@ paths:
         description: Updated data for 'core:MeasurementUnit' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3458,7 +3458,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3483,7 +3483,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3506,7 +3506,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3557,7 +3557,7 @@ paths:
         200:
           description: An array of 'core:QuantityKind' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -3576,7 +3576,7 @@ paths:
         description: New 'core:QuantityKind' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3594,7 +3594,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3624,7 +3624,7 @@ paths:
         200:
           description: A 'core:QuantityKind' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3649,7 +3649,7 @@ paths:
         description: Updated data for 'core:QuantityKind' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3669,7 +3669,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3694,7 +3694,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3717,7 +3717,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3768,7 +3768,7 @@ paths:
         200:
           description: An array of 'core:RealEstate' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -3787,7 +3787,7 @@ paths:
         description: New 'core:RealEstate' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3805,7 +3805,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3835,7 +3835,7 @@ paths:
         200:
           description: A 'core:RealEstate' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3860,7 +3860,7 @@ paths:
         description: Updated data for 'core:RealEstate' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3880,7 +3880,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3905,7 +3905,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -3928,7 +3928,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -3979,7 +3979,7 @@ paths:
         200:
           description: An array of 'core:RealEstateComponent' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -3998,7 +3998,7 @@ paths:
         description: New 'core:RealEstateComponent' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4016,7 +4016,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4046,7 +4046,7 @@ paths:
         200:
           description: A 'core:RealEstateComponent' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4071,7 +4071,7 @@ paths:
         description: Updated data for 'core:RealEstateComponent' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4091,7 +4091,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4116,7 +4116,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4139,7 +4139,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4334,7 +4334,7 @@ paths:
         200:
           description: An array of 'core:Sensor' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -4358,7 +4358,7 @@ paths:
         description: New 'core:Sensor' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4376,7 +4376,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4410,7 +4410,7 @@ paths:
         200:
           description: A 'core:Sensor' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4439,7 +4439,7 @@ paths:
         description: Updated data for 'core:Sensor' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4459,7 +4459,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4488,7 +4488,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4511,7 +4511,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4560,7 +4560,7 @@ paths:
         200:
           description: An array of 'building:RoomType' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -4579,7 +4579,7 @@ paths:
         description: New 'building:RoomType' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4597,7 +4597,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4627,7 +4627,7 @@ paths:
         200:
           description: A 'building:RoomType' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4652,7 +4652,7 @@ paths:
         description: Updated data for 'building:RoomType' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4672,7 +4672,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4697,7 +4697,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4720,7 +4720,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4783,7 +4783,7 @@ paths:
         200:
           description: An array of 'building:Storey' objects.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HydraCollectionWrapper'
@@ -4802,7 +4802,7 @@ paths:
         description: New 'building:Storey' entity that is to be added.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4820,7 +4820,7 @@ paths:
         201:
           description: Entity was successfully created (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4850,7 +4850,7 @@ paths:
         200:
           description: A 'building:Storey' object.
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4875,7 +4875,7 @@ paths:
         description: Updated data for 'building:Storey' entity.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4895,7 +4895,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object
@@ -4920,7 +4920,7 @@ paths:
         description: A single JSON key-value pair (plus @context), indicating the property to update and its new value. Note that the Swagger UI does not properly show the size constraint on this parameter; but the underlying OpenAPI Specification document does.
         required: true
         content:
-          application/json:
+          application/ld+json:
             schema:
               allOf:
               - type: object
@@ -4943,7 +4943,7 @@ paths:
         200:
           description: Entity was updated successfully (new representation returned).
           content:
-            application/jsonld:
+            application/ld+json:
               schema:
                 allOf:
                 - type: object

--- a/api/edge_messages/README.md
+++ b/api/edge_messages/README.md
@@ -8,7 +8,7 @@ The Edge Message specification is expressed using JSON Schema (see [json-schema.
 ## Edge Message Walkthrough
 
 The format corresponds to a version of RealEstateCore and is stated at the root of the message, so that different versions devices using different versions can be used next to each other, but still parsed correctly.  
-`"format": "rec3.1.1"`
+`"format": "rec3.1.2"`
 
 Edge messages are sent to or from core:Devices. Hence Device Id is also included in the message root.  
 `"deviceId":"myDeviceId"`

--- a/api/edge_messages/edge_message.schema.json
+++ b/api/edge_messages/edge_message.schema.json
@@ -1,7 +1,7 @@
 {
   "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://w3id.org/rec/edge_message/3.1.1/",
+  "$id": "https://w3id.org/rec/edge_message/3.1.2/",
   "type": "object",
   "title": "RealEstateCore Edge Message Schema",
   "required": [
@@ -10,18 +10,18 @@
   ],
   "properties": {
     "format": {
-      "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/format",
+      "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/format",
       "type": "string",
       "title": "The Format Schema",
       "description": "REC edge message version",
-      "default": "rec3.1.1",
+      "default": "rec3.1.2",
       "examples": [
         "rec3.2"
       ],
       "pattern": "^(.*)$"
     },
     "deviceId": {
-      "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/deviceId",
+      "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/deviceId",
       "type": "string",
       "title": "The DeviceId Schema,",
       "description": "Either IRI or ID of Device",
@@ -32,12 +32,12 @@
       "pattern": "^(.*)$"
     },
     "observations": {
-      "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations",
+      "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations",
       "type": "array",
       "title": "The Observations Array Schema",
       "default": null,
       "items": {
-        "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items",
+        "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items",
         "type": "object",
         "title": "The Observation Schema",
         "default": null,
@@ -53,7 +53,7 @@
         ],
         "properties": {
           "observationTime": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items/properties/observationTime",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items/properties/observationTime",
             "type": "string",
             "title": "The ObservationTime Schema",
             "description": "ISO 8601 date-time string, UTC",
@@ -65,7 +65,7 @@
             "format": null
           },
           "value": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items/properties/value",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items/properties/value",
             "type": "number",
             "title": "The Value Schema",
             "description": "Observed value (number)",
@@ -75,7 +75,7 @@
             ]
           },
           "valueString": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items/properties/valueString",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items/properties/valueString",
             "type": "string",
             "title": "The ValueString Schema",
             "description": "Observed value (string)",
@@ -86,7 +86,7 @@
             "pattern": "^(.*)$"
           },
           "valueBoolean": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items/properties/valueBoolean",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items/properties/valueBoolean",
             "type": "boolean",
             "title": "The ValueBoolean Schema",
             "description": "Observed Value (Boolean)",
@@ -96,7 +96,7 @@
             ]
           },
           "quantityKind": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items/properties/quantityKind",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items/properties/quantityKind",
             "type": "string",
             "title": "The QuantityKind Schema",
             "description": "quantityKind",
@@ -108,7 +108,7 @@
             "format": "iri"
           },
           "sensorId": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/observations/items/properties/sensorId",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/observations/items/properties/sensorId",
             "type": "string",
             "title": "The SensorId Schema",
             "description": "IRI or ID of Sensor",
@@ -122,12 +122,12 @@
       }
     },
     "actuationCommands": {
-      "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands",
+      "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands",
       "type": "array",
       "title": "The ActuationCommands Array Schema",
       "default": null,
       "items": {
-        "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items",
+        "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items",
         "type": "object",
         "title": "The ActuationCommand Schema",
         "default": null,
@@ -143,7 +143,7 @@
         ],
         "properties": {
           "actuationCommandTime": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items/properties/actuationCommandTime",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items/properties/actuationCommandTime",
             "type": "string",
             "title": "The ActuationCommandTime Schema",
             "description": "DateTime of ActuationCommand (ISO 8601 UTC)",
@@ -155,7 +155,7 @@
             "format": null
           },
           "actuationCommandId": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items/properties/actuationId",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items/properties/actuationId",
             "type": "string",
             "title": "The ActuationCommandId Schema",
             "description": "IRI or ID of Actuation",
@@ -166,7 +166,7 @@
             "pattern": "^(.*)$"
           },
           "actuatorId": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items/properties/actuatorId",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items/properties/actuatorId",
             "type": "string",
             "title": "The ActuatorId Schema",
             "description": "IRI or ID of Actuator",
@@ -177,7 +177,7 @@
             "pattern": "^(.*)$"
           },
           "value": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items/properties/value",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items/properties/value",
             "type": "number",
             "title": "The Value Schema",
             "description": "Value to be actuated, validated with ActuationInterface",
@@ -187,7 +187,7 @@
             ]
           },
           "valueString": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items/properties/valueString",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items/properties/valueString",
             "type": "string",
             "title": "The ValueString Schema",
             "description": "Value to be actuated, validated with ActuationInterface",
@@ -198,7 +198,7 @@
             "pattern": "^(.*)$"
           },
           "valueBoolean": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationCommands/items/properties/valueBoolean",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationCommands/items/properties/valueBoolean",
             "type": "boolean",
             "title": "The ValueBoolean Schema",
             "description": "Value to be actuated, validated with ActuationInterface",
@@ -211,12 +211,12 @@
       }
     },
     "actuationResponses": {
-      "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationResponses",
+      "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationResponses",
       "type": "array",
       "title": "The ActuationResponses Array Schema",
       "default": null,
       "items": {
-        "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationResponses/items",
+        "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationResponses/items",
         "type": "object",
         "title": "The ActuationResponse Schema",
         "default": null,
@@ -228,7 +228,7 @@
         ],
         "properties": {
           "actuatorId": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationResponses/items/properties/actuatorId",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationResponses/items/properties/actuatorId",
             "type": "string",
             "title": "The ActuatorId Schema",
             "description": "IRI or ID of Actuator",
@@ -239,7 +239,7 @@
             "pattern": "^(.*)$"
           },
           "actuationCommandId": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationResponses/items/properties/actuationId",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationResponses/items/properties/actuationId",
             "type": "string",
             "title": "The ActuationId Schema",
             "description": "IRI or ID of Actuation",
@@ -250,7 +250,7 @@
             "pattern": "^(.*)$"
           },
           "responseCode": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationResponses/items/properties/responseCode",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationResponses/items/properties/responseCode",
             "type": "string",
             "title": "The ResponseCode Schema",
             "description": "Response code from actuator",
@@ -268,7 +268,7 @@
             "pattern": "^(.*)$"
           },
           "actuationResponseTime": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/actuationResponses/items/properties/actuationResponseTime",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/actuationResponses/items/properties/actuationResponseTime",
             "type": "string",
             "title": "The ActuationResponseTime Schema",
             "description": "Time of ActuationResponse, ISO 8601 UTC",
@@ -283,12 +283,12 @@
       }
     },
     "exceptions": {
-      "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions",
+      "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions",
       "type": "array",
       "title": "The Exceptions Array Schema",
       "default": null,
       "items": {
-        "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions/items",
+        "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions/items",
         "type": "object",
         "title": "The Exception Schema",
         "default": null,
@@ -300,7 +300,7 @@
         ],
         "properties": {
           "exceptionTime": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions/items/properties/exceptionTime",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions/items/properties/exceptionTime",
             "type": "string",
             "title": "The ExceptionTime Schema",
             "description": "Time of Exception, ISO 8601 UTC",
@@ -312,7 +312,7 @@
             "format": null
           },
           "origin": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions/items/properties/origin",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions/items/properties/origin",
             "type": "string",
             "title": "The Origin Schema",
             "description": "The type of device from where the exception originates. \"sensor\" if exception when making observation, \"actuator\" if exception while making actuation",
@@ -330,7 +330,7 @@
             "pattern": "^(.*)$"
           },
           "id": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions/items/properties/id",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions/items/properties/id",
             "type": "string",
             "title": "The Id Schema",
             "description": "IRI or ID of device, sensor or actuator from where the exception originates",
@@ -341,7 +341,7 @@
             "pattern": "^(.*)$"
           },
           "exception": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions/items/properties/exception",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions/items/properties/exception",
             "type": "string",
             "title": "The ExceptionMessage Schema",
             "description": "exceptionMessage, more info about exception",
@@ -352,7 +352,7 @@
             "pattern": "^(.*)$"
           },
           "retry": {
-            "$id": "https://w3id.org/rec/edge_message/3.1.1/#/properties/exceptions/items/properties/retry",
+            "$id": "https://w3id.org/rec/edge_message/3.1.2/#/properties/exceptions/items/properties/retry",
             "type": "integer",
             "title": "The Retry Count Schema",
             "description": "Number of retries, if it is a repeating exception",

--- a/api/edge_messages/edge_message_example.json
+++ b/api/edge_messages/edge_message_example.json
@@ -1,5 +1,5 @@
 {
-  "format": "rec3.1.1",
+  "format": "rec3.1.2",
   "deviceId": "https://recref.com/device/64b65a99-a53c-47f5-b959-1c7a641d82d8",
   "observations": [
     {

--- a/ontology/actuation.rdf
+++ b/ontology/actuation.rdf
@@ -15,8 +15,8 @@
      xmlns:actuation="https://w3id.org/rec/actuation/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/actuation/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/actuation/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/device/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/actuation/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/device/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:creator>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Per Karlberg</dc:creator>
@@ -25,8 +25,8 @@
         <dc:title>RealEstateCore Actuation Module</dc:title>
         <terms:modified>2020-04-21</terms:modified>
         <vann:preferredNamespacePrefix>actuation</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/actuation/3.1.1/</vann:preferredNamespaceUri>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.1</owl:versionInfo>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/actuation/3.1.2/</vann:preferredNamespaceUri>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/agents.rdf
+++ b/ontology/agents.rdf
@@ -15,8 +15,8 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/agents/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/agents/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/agents/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:creator>
         <dc:description xml:lang="en">This REC model covers basic types of agents (people, organizations, groups), structurally mostly aligned with FOAF -- divergences are noted in the respective propertys&apos; documentation.</dc:description>
@@ -24,13 +24,13 @@
         <dc:title>RealEstateCore Agents Module</dc:title>
         <dcterms:modified>2020-04-21</dcterms:modified>
         <vann:preferredNamespacePrefix>agents</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/agents/3.1.1/</vann:preferredNamespaceUri>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/agents/3.1.2/</vann:preferredNamespaceUri>
         <cpannotationschema:coversRequirements xml:lang="en">What is Karl Hammar&apos;s GitHub account ID?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">What is the RealEstateCore organizational GitHub account ID?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">Who are the members of the RealEstateCore release engineering team?</cpannotationschema:coversRequirements>
         <rdfs:comment xml:lang="en">The Agents module is work-in-progress; requirements are rather unclear as of yet.</rdfs:comment>
         <rdfs:seeAlso rdf:resource="https://w3id.org/rec/"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/building.rdf
+++ b/ontology/building.rdf
@@ -15,8 +15,8 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/building/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/building/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/building/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:contributor>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erik Wallin</dc:creator>
@@ -25,14 +25,14 @@
         <dc:title>RealEstateCore Building Module</dc:title>
         <dcterms:modified>2020-04-21</dcterms:modified>
         <vann:preferredNamespacePrefix>building</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/building/3.1.1/</vann:preferredNamespaceUri>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/building/3.1.2/</vann:preferredNamespaceUri>
         <cpannotationschema:coversRequirements xml:lang="en">Are there any labs in Building 7?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">How many entrances are there to Building 7?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">How many of each type of room does Building 7 contain?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">What equipment is mounted in server rooms in Building 7?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">Which facade- or roof-mounted sensors are installed in Building 7?</cpannotationschema:coversRequirements>
         <rdfs:seeAlso rdf:resource="https://w3id.org/rec/"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/catalog-v001.xml
+++ b/ontology/catalog-v001.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="https://w3id.org/rec/actuation/3.1.1/" uri="actuation.rdf"/>
-    <uri id="User Edited Redirect" name="https://w3id.org/rec/metadata/3.1.1/" uri="metadata.rdf"/>
-    <uri id="User Edited Redirect" name="https://w3id.org/rec/core/3.1.1/" uri="core.rdf"/>
-    <uri id="User Edited Redirect" name="https://w3id.org/rec/device/3.1.1/" uri="device.rdf"/>
-    <uri id="User Edited Redirect" name="https://w3id.org/rec/building/3.1.1/" uri="building.rdf"/>
-    <uri id="User Edited Redirect" name="https://w3id.org/rec/lease/3.1.1/" uri="lease.rdf"/>
-    <uri id="User Edited Redirect" name="https://w3id.org/rec/agents/3.1.1/" uri="agents.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/rec/actuation/3.1.2/" uri="actuation.rdf"/>
+    <uri id="User Edited Redirect" name="https://w3id.org/rec/metadata/3.1.2/" uri="metadata.rdf"/>
+    <uri id="User Edited Redirect" name="https://w3id.org/rec/core/3.1.2/" uri="core.rdf"/>
+    <uri id="User Edited Redirect" name="https://w3id.org/rec/device/3.1.2/" uri="device.rdf"/>
+    <uri id="User Edited Redirect" name="https://w3id.org/rec/building/3.1.2/" uri="building.rdf"/>
+    <uri id="User Edited Redirect" name="https://w3id.org/rec/lease/3.1.2/" uri="lease.rdf"/>
+    <uri id="User Edited Redirect" name="https://w3id.org/rec/agents/3.1.2/" uri="agents.rdf"/>
 </catalog>

--- a/ontology/core.rdf
+++ b/ontology/core.rdf
@@ -17,8 +17,8 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/core/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/core/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/metadata/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/core/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/metadata/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erik Wallin</dc:creator>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:creator>
@@ -29,7 +29,7 @@ Note that this module reuses certain classes, properties, and named individuals 
         <dc:title>RealEstateCore Core Module</dc:title>
         <dcterms:modified>2020-04-21</dcterms:modified>
         <vann:preferredNamespacePrefix>core</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/core/3.1.1/</vann:preferredNamespaceUri>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/core/3.1.2/</vann:preferredNamespaceUri>
         <cpannotationschema:coversRequirements xml:lang="en">How many rooms are there in Building 1?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">What does electricity meter 3 measure? In what units?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">Where in Building 1 (i.e., in which rooms) are there devices mounted?</cpannotationschema:coversRequirements>
@@ -38,7 +38,7 @@ Note that this module reuses certain classes, properties, and named individuals 
         <cpannotationschema:coversRequirements xml:lang="en">Which buildings and land make up the real estate Ulvsnaes 1:7?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">Which parts of Building 1 (e.g., rooms, wings, etc) are covered by electricity meter 3?</cpannotationschema:coversRequirements>
         <rdfs:seeAlso rdf:resource="https://realestatecore.io"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/device.rdf
+++ b/ontology/device.rdf
@@ -15,8 +15,8 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/device/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/device/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/device/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:contributor>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erik Wallin</dc:creator>
@@ -25,7 +25,7 @@
         <dc:title>RealEstateCore Device Module</dc:title>
         <dcterms:modified>2020-04-21</dcterms:modified>
         <vann:preferredNamespacePrefix>device</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/device/3.1.1/</vann:preferredNamespaceUri>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/device/3.1.2/</vann:preferredNamespaceUri>
         <cpannotationschema:coversRequirements xml:lang="en">At what time was an actuation received by the building system, and at what time was it executed?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">Does temperature sensor TMP882 measure inside or outside temperature?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">Does water temperature sensor TMP334 measure incoming water temperature, or return water temperature?</cpannotationschema:coversRequirements>
@@ -41,7 +41,7 @@
         <cpannotationschema:coversRequirements xml:lang="en">Which sensor did observation/datapoint OBS-846294-PID22-88 come from?</cpannotationschema:coversRequirements>
         <rdfs:comment xml:lang="en">The actuation model is deployed and works in practice with the stakeholders, but we need to update the model to reflect current practice in their systems; e.g., extend the semantics a little and formalize standard state messages, response codes, etc.</rdfs:comment>
         <rdfs:seeAlso rdf:resource="https://w3id.org/rec/"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/full.rdf
+++ b/ontology/full.rdf
@@ -46,6 +46,10 @@
         <rdfs:comment xml:lang="en">Version 3.1.2 is a bug fix release that addresses an issue in the REST API specification.
 
 * The REC REST API specification (api/REST/rec-full-v3.1.2.yaml) now specifies that the payload for POST, PUT, and PATCH operations should be carried in the HTTP request body.        
+* The REC REST API specification now uses the updated MIME type for JSON-LD: application/ld+json
+* The Edge message examples mistakenly carried REC 2 semantics due to previous Git mishap; that is now addressed and the examples are up-to-date
+
+Note that this hotfix does not affect the ontology semantics; aside from version and release node annotations, REC 3.1.2 is identical to REC 3.1.2.
 
 Version 3.1.1 is a minor release of REC that contains:
 

--- a/ontology/full.rdf
+++ b/ontology/full.rdf
@@ -23,14 +23,14 @@
      xmlns:collections="https://w3id.org/rec/collections/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/full/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/full/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/actuation/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/agents/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/building/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/device/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/lease/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/metadata/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/full/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/actuation/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/agents/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/building/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/device/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/lease/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/metadata/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:contributor>Håkan Eriksson</dc:contributor>
         <dc:contributor>Joakim Eriksson</dc:contributor>
@@ -42,8 +42,8 @@
         <dc:publisher>RealEstateCore Consortium</dc:publisher>
         <dc:title>RealEstateCore Full</dc:title>
         <vann:preferredNamespacePrefix>rec</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/full/3.1.1/</vann:preferredNamespaceUri>
-        <rdfs:comment xml:lang="en">Version 3.1.1 is a minor release of REC that contains:
+        <vann:preferredNamespaceUri>https://w3id.org/rec/full/3.1.2/</vann:preferredNamespaceUri>
+        <rdfs:comment xml:lang="en">Version 3.1.2 is a minor release of REC that contains:
 
 * The official REC REST API (see the api/REST subdirectory)
 * O2O annotations used by the OWL2OAS generator when building that API.
@@ -68,7 +68,7 @@ Version 3.0 is a major and compatibility-breaking refactoring of REC:
 * All entities have been assigned rdfs:labels and the large majority rdfs:comments.
 * The modules have been documented with metadata using DC, CC, VANN, cpannotationschema, etc.
 * All IRI:s are now HTTPS</rdfs:comment>
-        <owl:versionInfo xml:lang="en">3.1.1</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/full.rdf
+++ b/ontology/full.rdf
@@ -43,7 +43,11 @@
         <dc:title>RealEstateCore Full</dc:title>
         <vann:preferredNamespacePrefix>rec</vann:preferredNamespacePrefix>
         <vann:preferredNamespaceUri>https://w3id.org/rec/full/3.1.2/</vann:preferredNamespaceUri>
-        <rdfs:comment xml:lang="en">Version 3.1.2 is a minor release of REC that contains:
+        <rdfs:comment xml:lang="en">Version 3.1.2 is a bug fix release that addresses an issue in the REST API specification.
+
+* The REC REST API specification (api/REST/rec-full-v3.1.2.yaml) now specifies that the payload for POST, PUT, and PATCH operations should be carried in the HTTP request body.        
+
+Version 3.1.1 is a minor release of REC that contains:
 
 * The official REC REST API (see the api/REST subdirectory)
 * O2O annotations used by the OWL2OAS generator when building that API.

--- a/ontology/lease.rdf
+++ b/ontology/lease.rdf
@@ -15,8 +15,8 @@
      xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/lease/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/lease/3.1.1/"/>
-        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/lease/3.1.2/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/core/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:creator>Erik Wallin</dc:creator>
         <dc:creator>Karl Hammar</dc:creator>
@@ -25,7 +25,7 @@
         <dc:title>RealEstateCore Lease Module</dc:title>
         <dcterms:modified>2020-04-21</dcterms:modified>
         <vann:preferredNamespacePrefix>lease</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/lease/3.1.1/</vann:preferredNamespaceUri>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/lease/3.1.2/</vann:preferredNamespaceUri>
         <cpannotationschema:coversRequirements xml:lang="en">Who owns Building 7?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">What contract governs the lease of building 7?</cpannotationschema:coversRequirements>
         <cpannotationschema:coversRequirements xml:lang="en">What purpose is Building 7 leased for?</cpannotationschema:coversRequirements>
@@ -33,7 +33,7 @@
         <cpannotationschema:coversRequirements xml:lang="en">Who is leasing Building 7?</cpannotationschema:coversRequirements>
         <rdfs:comment xml:lang="en">The LeaseContract class is as of yet underdefined -- we need to liaise with legal expertise to define the requirements here. Also, lease remuneration needs to be modelled. The base case, monthly rent, is easy -- but more complex and forward-looking payment models are likely to be relevant in some use cases also.</rdfs:comment>
         <rdfs:seeAlso rdf:resource="https://w3id.org/rec/"/>
-        <owl:versionInfo>3.1.1</owl:versionInfo>
+        <owl:versionInfo>3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 

--- a/ontology/metadata.rdf
+++ b/ontology/metadata.rdf
@@ -17,7 +17,7 @@
      xmlns:metadata="https://w3id.org/rec/metadata/"
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/metadata/">
-        <owl:versionIRI rdf:resource="https://w3id.org/rec/metadata/3.1.1/"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/metadata/3.1.2/"/>
         <cc:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:contributor>Erik Wallin</dc:contributor>
         <dc:contributor>Karl Hammar</dc:contributor>
@@ -30,14 +30,14 @@ The copyright on the constituent parts (classes, properties, named individuals) 
         <dc:title>RealEstateCore Metadata Module</dc:title>
         <dcterms:modified>2020-04-21</dcterms:modified>
         <vann:preferredNamespacePrefix>metadata</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri>https://w3id.org/rec/metadata/3.1.1/</vann:preferredNamespaceUri>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/metadata/3.1.2/</vann:preferredNamespaceUri>
         <rdfs:isDefinedBy rdf:resource="http://creativecommons.org/ns#"/>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/terms/"/>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/vocab/vann/"/>
         <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#"/>
         <rdfs:isDefinedBy rdf:resource="https://karlhammar.com/owl2oas/o2o.owl#"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.1.2</owl:versionInfo>
     </owl:Ontology>
 
 


### PR DESCRIPTION
Version 3.1.2 is a bug fix release that addresses an issue in the REST API specification.

* The REC REST API specification (api/REST/rec-full-v3.1.2.yaml) now specifies that the payload for POST, PUT, and PATCH operations should be carried in the HTTP request body.        
* The REC REST API specification now uses the updated MIME type for JSON-LD: application/ld+json
* The Edge message examples mistakenly carried REC 2 semantics due to previous Git mishap; that is now addressed and the examples are up-to-date