### PR TITLE
Update example.rdf

### DIFF
--- a/ontology/example.rdf
+++ b/ontology/example.rdf
@@ -37,143 +37,6 @@
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
-    // Annotation properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- https://w3id.org/rec/actuation/hasActuationInterface -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/actuation/hasActuationInterface"/>
-    
-
-
-    <!-- https://w3id.org/rec/actuation/hasDefaultActuationInterface -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/actuation/hasDefaultActuationInterface"/>
-    
-
-
-    <!-- https://w3id.org/rec/building/roomType -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/building/roomType"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/containsMountedDevice -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/containsMountedDevice"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/dataSchema -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/dataSchema"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasBuildingComponent -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasBuildingComponent"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasMeasurementUnit -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasMeasurementUnit"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasQuantityKind -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasQuantityKind"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasRealEstateComponent -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasRealEstateComponent"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasSubBuildingComponent -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasSubBuildingComponent"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasSubDevice -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasSubDevice"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasSuperBuildingComponent -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasSuperBuildingComponent"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/hasSuperDevice -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/hasSuperDevice"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/isMountedIn -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/isMountedIn"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/isPartOfBuilding -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/isPartOfBuilding"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/isPartOfRealEstate -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/isPartOfRealEstate"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/measurementUnit -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/measurementUnit"/>
-    
-
-
-    <!-- https://w3id.org/rec/core/quantityKind -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/core/quantityKind"/>
-    
-
-
-    <!-- https://w3id.org/rec/dataschemas/maximum -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/dataschemas/maximum"/>
-    
-
-
-    <!-- https://w3id.org/rec/dataschemas/minimum -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/dataschemas/minimum"/>
-    
-
-
-    <!-- https://w3id.org/rec/device/sensorInterface -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/rec/device/sensorInterface"/>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
     // Individuals
     //
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -242,8 +105,6 @@
         <core:hasMeasurementUnit rdf:resource="https://w3id.org/rec/core/Lux"/>
         <core:hasQuantityKind rdf:resource="https://w3id.org/rec/core/Illuminance"/>
         <core:hasSuperDevice rdf:resource="https://w3id.org/rec/example/HueMotionSensor1"/>
-        <core:measurementUnit rdf:resource="https://w3id.org/rec/core/Lux"/>
-        <core:quantityKind rdf:resource="https://w3id.org/rec/core/Illuminance"/>
         <device:sensorInterface rdf:resource="https://w3id.org/rec/example/HueMotionSensorLightMeterInterface"/>
     </owl:NamedIndividual>
     
@@ -256,7 +117,6 @@
         <core:hasMeasurementUnit rdf:resource="https://w3id.org/rec/core/BooleanDetection"/>
         <core:hasQuantityKind rdf:resource="https://w3id.org/rec/core/Presence"/>
         <core:hasSuperDevice rdf:resource="https://w3id.org/rec/example/HueMotionSensor1"/>
-        <core:quantityKind rdf:resource="https://w3id.org/rec/core/Presence"/>
         <device:sensorInterface rdf:resource="https://w3id.org/rec/example/HueMotionSensorMotionDetectorInterface"/>
     </owl:NamedIndividual>
     
@@ -269,8 +129,6 @@
         <core:hasMeasurementUnit rdf:resource="https://w3id.org/rec/core/Celsius"/>
         <core:hasQuantityKind rdf:resource="https://w3id.org/rec/core/Temperature"/>
         <core:hasSuperDevice rdf:resource="https://w3id.org/rec/example/HueMotionSensor1"/>
-        <core:measurementUnit rdf:resource="https://w3id.org/rec/core/Celsius"/>
-        <core:quantityKind rdf:resource="https://w3id.org/rec/core/Temperature"/>
         <device:sensorInterface rdf:resource="https://w3id.org/rec/example/HueMotionSensorThermometerInterface"/>
     </owl:NamedIndividual>
     


### PR DESCRIPTION
The example.rdf file was inconsistent in release 3.2; it used properties for quantitykinds and measurement units from 3.3.