### PR TITLE
Pluggable addressing module

### DIFF
--- a/ontology/addressing.rdf
+++ b/ontology/addressing.rdf
@@ -45,11 +45,11 @@
     
 
 
-    <!-- https://w3id.org/rec/addressing/hasAddress -->
+    <!-- https://w3id.org/rec/addressing/address -->
 
-    <owl:ObjectProperty rdf:about="https://w3id.org/rec/addressing/hasAddress">
+    <owl:ObjectProperty rdf:about="https://w3id.org/rec/addressing/address">
         <rdfs:range rdf:resource="https://w3id.org/rec/addressing/Address"/>
-        <rdfs:label xml:lang="en">has address</rdfs:label>
+        <rdfs:label xml:lang="en">address</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -151,7 +151,7 @@
     <rdf:Description rdf:about="https://w3id.org/rec/core/Building">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/hasAddress"/>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/address"/>
                 <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -164,7 +164,7 @@
     <rdf:Description rdf:about="https://w3id.org/rec/core/Land">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/hasAddress"/>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/address"/>
                 <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -177,7 +177,7 @@
     <rdf:Description rdf:about="https://w3id.org/rec/core/SubBuilding">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/hasAddress"/>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/address"/>
                 <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
             </owl:Restriction>
         </rdfs:subClassOf>

--- a/ontology/addressing.rdf
+++ b/ontology/addressing.rdf
@@ -20,6 +20,7 @@
      xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
     <owl:Ontology rdf:about="https://w3id.org/rec/addressing/">
         <owl:versionIRI rdf:resource="https://w3id.org/rec/addressing/3.3/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/business/3.3/"/>
         <owl:imports rdf:resource="https://w3id.org/rec/core/3.3/"/>
         <ns:license rdf:resource="https://opensource.org/licenses/MIT"/>
         <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:creator>
@@ -143,6 +144,19 @@
         <rdfs:label xml:lang="en">Address</rdfs:label>
         <metadata:dtdlType>component</metadata:dtdlType>
     </owl:Class>
+    
+
+
+    <!-- https://w3id.org/rec/business/TenantUnit -->
+
+    <rdf:Description rdf:about="https://w3id.org/rec/business/TenantUnit">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/address"/>
+                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
     
 
 

--- a/ontology/addressing.rdf
+++ b/ontology/addressing.rdf
@@ -1,0 +1,190 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="https://w3id.org/rec/addressing/"
+     xml:base="https://w3id.org/rec/addressing/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:ns="http://creativecommons.org/ns#"
+     xmlns:o2o="https://karlhammar.com/owl2oas/o2o.owl#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:core="http://www.linkedmodel.org/owl/schema/core#"
+     xmlns:qudt="http://qudt.org/schema/qudt/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:vaem="http://www.linkedmodel.org/schema/vaem#"
+     xmlns:vann="http://purl.org/vocab/vann/"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:metadata="https://w3id.org/rec/metadata/"
+     xmlns:addressing="https://w3id.org/rec/addressing/"
+     xmlns:cpannotationschema="http://www.ontologydesignpatterns.org/schemas/cpannotationschema.owl#">
+    <owl:Ontology rdf:about="https://w3id.org/rec/addressing/">
+        <owl:versionIRI rdf:resource="https://w3id.org/rec/addressing/3.3/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/core/3.3/"/>
+        <ns:license rdf:resource="https://opensource.org/licenses/MIT"/>
+        <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karl Hammar</dc:creator>
+        <dc:description xml:lang="en">This pluggable REC module covers the addressing domain.</dc:description>
+        <dc:publisher>RealEstateCore Consortium</dc:publisher>
+        <dc:title>RealEstateCore Addressing Module</dc:title>
+        <terms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2021-09-14</terms:modified>
+        <vann:preferredNamespacePrefix>addressing</vann:preferredNamespacePrefix>
+        <vann:preferredNamespaceUri>https://w3id.org/rec/addressing/3.3/</vann:preferredNamespaceUri>
+        <owl:versionInfo xml:lang="en">3.3</owl:versionInfo>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://w3id.org/rec/addressing/hasAddress -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/rec/addressing/hasAddress">
+        <rdfs:range rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:label xml:lang="en">has address</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://w3id.org/rec/addressing/addressLine1 -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/rec/addressing/addressLine1">
+        <rdfs:domain rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en">address line 1</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://w3id.org/rec/addressing/addressLine2 -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/rec/addressing/addressLine2">
+        <rdfs:domain rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en">address line 2</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://w3id.org/rec/addressing/city -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/rec/addressing/city">
+        <rdfs:domain rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en">city</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://w3id.org/rec/addressing/country -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/rec/addressing/country">
+        <rdfs:domain rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en">country</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://w3id.org/rec/addressing/postalCode -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/rec/addressing/postalCode">
+        <rdfs:domain rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en">postal code</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://w3id.org/rec/addressing/region -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/rec/addressing/region">
+        <rdfs:domain rdf:resource="https://w3id.org/rec/addressing/Address"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en">region (state/province)</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://w3id.org/rec/addressing/Address -->
+
+    <owl:Class rdf:about="https://w3id.org/rec/addressing/Address">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Information"/>
+        <rdfs:label xml:lang="en">Address</rdfs:label>
+        <metadata:dtdlType>component</metadata:dtdlType>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/rec/core/Building -->
+
+    <rdf:Description rdf:about="https://w3id.org/rec/core/Building">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/hasAddress"/>
+                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+    
+
+
+    <!-- https://w3id.org/rec/core/Land -->
+
+    <rdf:Description rdf:about="https://w3id.org/rec/core/Land">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/hasAddress"/>
+                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+    
+
+
+    <!-- https://w3id.org/rec/core/SubBuilding -->
+
+    <rdf:Description rdf:about="https://w3id.org/rec/core/SubBuilding">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/addressing/hasAddress"/>
+                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/addressing/Address"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+

--- a/ontology/catalog-v001.xml
+++ b/ontology/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="https://w3id.org/rec/addressing/3.3/" uri="addressing.rdf"/>
     <uri id="Imports Wizard Entry" name="https://w3id.org/rec/units/3.3/" uri="units.rdf"/>
     <uri id="Imports Wizard Entry" name="https://w3id.org/rec/business/3.3/" uri="business.rdf"/>
     <uri id="Imports Wizard Entry" name="https://w3id.org/rec/asset/3.3/" uri="asset.rdf"/>

--- a/ontology/full.rdf
+++ b/ontology/full.rdf
@@ -26,6 +26,7 @@
     <owl:Ontology rdf:about="https://w3id.org/rec/full/">
         <owl:versionIRI rdf:resource="https://w3id.org/rec/full/3.3/"/>
         <owl:imports rdf:resource="https://w3id.org/rec/actuation/3.3/"/>
+        <owl:imports rdf:resource="https://w3id.org/rec/addressing/3.3/"/>
         <owl:imports rdf:resource="https://w3id.org/rec/agents/3.3/"/>
         <owl:imports rdf:resource="https://w3id.org/rec/analytics/3.3/"/>
         <owl:imports rdf:resource="https://w3id.org/rec/asset/3.3/"/>


### PR DESCRIPTION
After discussing with stakeholders, our existing street addressing approach seems inaccessible to them. 

The current approach is as follows:

* Space -- hasGeometry --> SomeGeometry
* SomeGeometry -- hasSerialization --> SomeSerialization
* Postal address, City address, etc are subproperties of hasSerialization

E.g., we consider addressing fields to be specializations of geometry serializations; in other words, addresses _are_ geometries. Conceptually this makes sense, but arguably for a developer who wants to build an app, perhaps we are getting too complex here. 

The module in this PR is fully self-contained and does not modify core. It provides:

1. a new namespace ("https://w3id.org/rec/addressing/"), 
2. a class within that namespace ("Address"), 
3. some commonly used properties on that class ("postal code", "address line 1", "address line 2", etc)
4. a property to link REC entities to addresses ("hasAddress")
5. Assertions that Buildings, Lands, and SubBuildings can have that property assigned to them