### PR TITLE
Renamed tags -> categorizationAttributes

### DIFF
--- a/ontology/core.rdf
+++ b/ontology/core.rdf
@@ -158,6 +158,15 @@ GeoSPARQL is Copyright (c) 2012 Open Geospatial Consortium, Inc. All Rights Rese
     
 
 
+    <!-- https://w3id.org/rec/core/categorizationAttributes -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/rec/core/categorizationAttributes">
+        <rdfs:range rdf:resource="https://w3id.org/rec/core/AttributeSet"/>
+        <rdfs:label xml:lang="en">categorization attributes</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/rec/core/componentOfBuilding -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/rec/core/componentOfBuilding">
@@ -731,15 +740,6 @@ Deprecated in favour of core:servesSpace</rdfs:comment>
 Deprecated in favour of core:servesAsset</rdfs:comment>
         <rdfs:label xml:lang="en">serves device</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- https://w3id.org/rec/core/tags -->
-
-    <owl:ObjectProperty rdf:about="https://w3id.org/rec/core/tags">
-        <rdfs:range rdf:resource="https://w3id.org/rec/core/TagSet"/>
-        <rdfs:label xml:lang="en">tags</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -1495,6 +1495,17 @@ GeoSPARQL is Copyright (c) 2012 Open Geospatial Consortium, Inc. All Rights Rese
     <owl:Class rdf:about="https://w3id.org/rec/core/AssetCollection">
         <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Collection"/>
         <rdfs:label xml:lang="en">Asset collection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/rec/core/AttributeSet -->
+
+    <owl:Class rdf:about="https://w3id.org/rec/core/AttributeSet">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Information"/>
+        <rdfs:comment xml:lang="en">A set of categorization attributes associated with a REC entity. Used for compatibility with legacy point- or tag-based systems.</rdfs:comment>
+        <rdfs:label xml:lang="en">Tag set</rdfs:label>
+        <metadata:dtdlType>component</metadata:dtdlType>
     </owl:Class>
     
 
@@ -2270,17 +2281,6 @@ Describes the type of values that can be observed by sensors or set by actuators
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A part of a larger building complex, e.g., a wing, a tower, or an interconnected (through walkways or other means) but largely free-standing building.</rdfs:comment>
         <rdfs:label xml:lang="en">Sub-building</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- https://w3id.org/rec/core/TagSet -->
-
-    <owl:Class rdf:about="https://w3id.org/rec/core/TagSet">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Information"/>
-        <rdfs:comment xml:lang="en">A set of categorization tags associated a REC entity. Used for compatibility with legacy point- or tag-based systems.</rdfs:comment>
-        <rdfs:label xml:lang="en">Tag set</rdfs:label>
-        <metadata:dtdlType>component</metadata:dtdlType>
     </owl:Class>
     
 

--- a/ontology/device.rdf
+++ b/ontology/device.rdf
@@ -327,7 +327,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/HVACMode -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/HVACMode">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -435,7 +435,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/alarm -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/alarm">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Notification of a condition which requires attention such as a threshold exceeded (Project Haystack). This differs from a Fault in that a Fault is used to identify a failure.</rdfs:comment>
         <rdfs:label xml:lang="en">alarm</rdfs:label>
@@ -446,7 +446,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/assetComponent -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/assetComponent">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -533,7 +533,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/demand -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/demand">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Rate required for a process. For a setpoint, this sets the required rate for a process such as cooling, heating, air flow, or water flow. For a sensor, this measures the rate of a process over a given interval such as electrical power demand or cooling energy demand.</rdfs:comment>
         <rdfs:label xml:lang="en">demand</rdfs:label>
@@ -544,7 +544,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/effective -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/effective">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Current control setpoint in effect taking into account other factors (Project Haystack).</rdfs:comment>
         <rdfs:label xml:lang="en">effective</rdfs:label>
@@ -555,7 +555,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/electricalPhase -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/electricalPhase">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -854,7 +854,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/limit -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/limit">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -881,7 +881,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/occupancyMode -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/occupancyMode">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -914,7 +914,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/phenomenon -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/phenomenon">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -1271,7 +1271,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/position -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/position">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -1436,7 +1436,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/stage -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/stage">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
         <rdfs:comment xml:lang="en">Stage number of a control loop for an equipment, equipment group, or system that is defined by the process controller. The first stage is 1, second stage 2, etc. (Project Haystack).</rdfs:comment>
         <rdfs:label xml:lang="en">stage</rdfs:label>
@@ -1460,8 +1460,8 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <rdf:Description rdf:about="https://w3id.org/rec/core/Capability">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/rec/core/tags"/>
-                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/device/CapabilityTagSet"/>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/core/categorizationAttributes"/>
+                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </rdf:Description>
@@ -2032,10 +2032,10 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     
 
 
-    <!-- https://w3id.org/rec/device/CapabilityTagSet -->
+    <!-- https://w3id.org/rec/device/CapabilityAttributeSet -->
 
-    <owl:Class rdf:about="https://w3id.org/rec/device/CapabilityTagSet">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/TagSet"/>
+    <owl:Class rdf:about="https://w3id.org/rec/device/CapabilityAttributeSet">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/AttributeSet"/>
         <rdfs:comment xml:lang="en">Encapuslates a set of tags that may be applicable to Capability instances.</rdfs:comment>
         <rdfs:label xml:lang="en">Capability tag set</rdfs:label>
         <metadata:dtdlType>component</metadata:dtdlType>


### PR DESCRIPTION
Customer rationale: tags are typically synonymous with labels, that are to some degree "markers" for a feature. We have string enumerations that we can connect to capabilities, and might in the future have even more complex structures. Tags is too simple an analogy. This is used to categorize the entities in question in a manner orthogonal to the subsumption hierarchy; thus "categorization attributes".