### PR TITLE
Renamed categorizationAttributes -> categorizationProperties

### DIFF
--- a/ontology/core.rdf
+++ b/ontology/core.rdf
@@ -158,11 +158,11 @@ GeoSPARQL is Copyright (c) 2012 Open Geospatial Consortium, Inc. All Rights Rese
     
 
 
-    <!-- https://w3id.org/rec/core/categorizationAttributes -->
+    <!-- https://w3id.org/rec/core/categorizationProperties -->
 
-    <owl:ObjectProperty rdf:about="https://w3id.org/rec/core/categorizationAttributes">
-        <rdfs:range rdf:resource="https://w3id.org/rec/core/AttributeSet"/>
-        <rdfs:label xml:lang="en">categorization attributes</rdfs:label>
+    <owl:ObjectProperty rdf:about="https://w3id.org/rec/core/categorizationProperties">
+        <rdfs:range rdf:resource="https://w3id.org/rec/core/PropertySet"/>
+        <rdfs:label xml:lang="en">categorization properties</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -1499,17 +1499,6 @@ GeoSPARQL is Copyright (c) 2012 Open Geospatial Consortium, Inc. All Rights Rese
     
 
 
-    <!-- https://w3id.org/rec/core/AttributeSet -->
-
-    <owl:Class rdf:about="https://w3id.org/rec/core/AttributeSet">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Information"/>
-        <rdfs:comment xml:lang="en">A set of categorization attributes associated with a REC entity. Used for compatibility with legacy point- or tag-based systems.</rdfs:comment>
-        <rdfs:label xml:lang="en">Tag set</rdfs:label>
-        <metadata:dtdlType>component</metadata:dtdlType>
-    </owl:Class>
-    
-
-
     <!-- https://w3id.org/rec/core/Building -->
 
     <owl:Class rdf:about="https://w3id.org/rec/core/Building">
@@ -1951,6 +1940,17 @@ MillimeterPerHour for Precipation</rdfs:comment>
         <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Type"/>
         <rdfs:label xml:lang="en">Premises type</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/rec/core/PropertySet -->
+
+    <owl:Class rdf:about="https://w3id.org/rec/core/PropertySet">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/Information"/>
+        <rdfs:comment xml:lang="en">A set of categorization properties associated with a REC entity, complementing the subsumpion hierarchy and allowing orthogonal categorization without the use of multiple inheritance structures. Used for compatibility with legacy point- or tag-based systems.</rdfs:comment>
+        <rdfs:label xml:lang="en">Property set</rdfs:label>
+        <metadata:dtdlType>component</metadata:dtdlType>
     </owl:Class>
     
 

--- a/ontology/device.rdf
+++ b/ontology/device.rdf
@@ -327,7 +327,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/HVACMode -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/HVACMode">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -435,7 +435,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/alarm -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/alarm">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Notification of a condition which requires attention such as a threshold exceeded (Project Haystack). This differs from a Fault in that a Fault is used to identify a failure.</rdfs:comment>
         <rdfs:label xml:lang="en">alarm</rdfs:label>
@@ -446,7 +446,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/assetComponent -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/assetComponent">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -533,7 +533,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/demand -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/demand">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Rate required for a process. For a setpoint, this sets the required rate for a process such as cooling, heating, air flow, or water flow. For a sensor, this measures the rate of a process over a given interval such as electrical power demand or cooling energy demand.</rdfs:comment>
         <rdfs:label xml:lang="en">demand</rdfs:label>
@@ -544,7 +544,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/effective -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/effective">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Current control setpoint in effect taking into account other factors (Project Haystack).</rdfs:comment>
         <rdfs:label xml:lang="en">effective</rdfs:label>
@@ -555,7 +555,7 @@ Deprecated in favour of core:observes</rdfs:comment>
     <!-- https://w3id.org/rec/device/electricalPhase -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/electricalPhase">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -854,7 +854,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/limit -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/limit">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -881,7 +881,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/occupancyMode -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/occupancyMode">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -914,7 +914,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/phenomenon -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/phenomenon">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -1271,7 +1271,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/position -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/position">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
@@ -1436,7 +1436,7 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <!-- https://w3id.org/rec/device/stage -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/rec/device/stage">
-        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+        <rdfs:domain rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
         <rdfs:comment xml:lang="en">Stage number of a control loop for an equipment, equipment group, or system that is defined by the process controller. The first stage is 1, second stage 2, etc. (Project Haystack).</rdfs:comment>
         <rdfs:label xml:lang="en">stage</rdfs:label>
@@ -1460,8 +1460,8 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     <rdf:Description rdf:about="https://w3id.org/rec/core/Capability">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/rec/core/categorizationAttributes"/>
-                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/device/CapabilityAttributeSet"/>
+                <owl:onProperty rdf:resource="https://w3id.org/rec/core/categorizationProperties"/>
+                <owl:allValuesFrom rdf:resource="https://w3id.org/rec/device/CapabilityPropertySet"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </rdf:Description>
@@ -2032,12 +2032,12 @@ Deprecated in favour of core:hasProcessedTime.</rdfs:comment>
     
 
 
-    <!-- https://w3id.org/rec/device/CapabilityAttributeSet -->
+    <!-- https://w3id.org/rec/device/CapabilityPropertySet -->
 
-    <owl:Class rdf:about="https://w3id.org/rec/device/CapabilityAttributeSet">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/AttributeSet"/>
-        <rdfs:comment xml:lang="en">Encapuslates a set of tags that may be applicable to Capability instances.</rdfs:comment>
-        <rdfs:label xml:lang="en">Capability tag set</rdfs:label>
+    <owl:Class rdf:about="https://w3id.org/rec/device/CapabilityPropertySet">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/rec/core/PropertySet"/>
+        <rdfs:comment xml:lang="en">Encapuslates a set of categorization properties that may be applicable to Capability instances.</rdfs:comment>
+        <rdfs:label xml:lang="en">Capability property set</rdfs:label>
         <metadata:dtdlType>component</metadata:dtdlType>
     </owl:Class>
     


### PR DESCRIPTION
After user feedback; better aligned with OWL and DTDL language features.