### PR TITLE
Implemented Georeference

### DIFF
--- a/Ontology/DTDLv2/RealEstateCore/Information/Georeference.json
+++ b/Ontology/DTDLv2/RealEstateCore/Information/Georeference.json
@@ -1,0 +1,64 @@
+{
+  "@id": "dtmi:org:w3id:rec:Georeference;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Property",
+      "description": {
+        "en": "Altitude"
+      },
+      "displayName": {
+        "en": "alt"
+      },
+      "name": "alt",
+      "schema": "float",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "description": {
+        "en": "The angle between local coordinate system and a north-south meridian."
+      },
+      "displayName": {
+        "en": "bearing"
+      },
+      "name": "bearing",
+      "schema": "float",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "description": {
+        "en": "Latitude"
+      },
+      "displayName": {
+        "en": "lat"
+      },
+      "name": "lat",
+      "schema": "float",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "description": {
+        "en": "Longitude"
+      },
+      "displayName": {
+        "en": "long"
+      },
+      "name": "long",
+      "schema": "float",
+      "writable": true
+    }
+  ],
+  "description": {
+    "en": "Encapsulates a georeference globally placing a spatially located entity in terms of latitude, longitude, altitude, and bearing."
+  },
+  "displayName": {
+    "en": "Georeference"
+  },
+  "extends": "dtmi:org:w3id:rec:Information;1",
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/Ontology/DTDLv2/RealEstateCore/Space/Space.json
+++ b/Ontology/DTDLv2/RealEstateCore/Space/Space.json
@@ -3,6 +3,17 @@
   "@type": "Interface",
   "contents": [
     {
+      "@type": "Component",
+      "description": {
+        "en": "A fixed point for, e.g., a building structure. Commonly refered to as \"insertion point\" in CAD-programs. Used as origo for locally defined geometries."
+      },
+      "displayName": {
+        "en": "georeference"
+      },
+      "name": "georeference",
+      "schema": "dtmi:org:w3id:rec:Georeference;1"
+    },
+    {
       "@type": "Property",
       "displayName": {
         "en": "Custom Tags"

--- a/Ontology/SHACL/RealEstateCore/rec.ttl
+++ b/Ontology/SHACL/RealEstateCore/rec.ttl
@@ -1004,6 +1004,48 @@ rec:Garage
   rdfs:label "Garage" ;
   rdfs:subClassOf rec:Room ;
 .
+rec:Georeference
+  a <dtmi:dtdl:class:Component> ;
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  rdfs:comment "Encapsulates a georeference globally placing a spatially located entity in terms of latitude, longitude, altitude, and bearing." ;
+  rdfs:label "Georeference" ;
+  rdfs:subClassOf rec:Information ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path rec:alt ;
+      sh:datatype xsd:float ;
+      sh:description "Altitude" ;
+      sh:maxCount 1 ;
+      sh:name "alt" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path rec:bearing ;
+      sh:datatype xsd:float ;
+      sh:description "The angle between local coordinate system and a north-south meridian." ;
+      sh:maxCount 1 ;
+      sh:name "bearing" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path rec:lat ;
+      sh:datatype xsd:float ;
+      sh:description "Latitude" ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "lat" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path rec:long ;
+      sh:datatype xsd:float ;
+      sh:description "Longitude" ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "long" ;
+    ] ;
+.
 rec:GroupRoom
   a rdfs:Class ;
   a sh:NodeShape ;
@@ -1796,6 +1838,15 @@ rec:Space
       sh:description "A GeoJSON Polygon coordinate listing representing the geometrical representation of the space. Coordinates may be expressed in two or three dimensions. Ex: [[30.0, 10.0, 0.0], [40.0, 40.0, 2.0], [20.0, 40.0, 2.0], [10.0, 20.0, 2.0], [30.0, 10.0, 0.0]]." ;
       sh:maxCount 1 ;
       sh:name "geometry" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path rec:georeference ;
+      sh:class rec:Georeference ;
+      sh:description "A fixed point for, e.g., a building structure. Commonly refered to as \"insertion point\" in CAD-programs. Used as origo for locally defined geometries." ;
+      sh:maxCount 1 ;
+      sh:name "georeference" ;
+      sh:nodeKind sh:IRI ;
     ] ;
   sh:property [
       a sh:PropertyShape ;


### PR DESCRIPTION
Ported geoReferenceOrigo and geoReferenceBearing from REC 3.3, but adapted to DTDL language constructs (Component rather than Property) and using what seems from Wikipedia to be standard capitalization rules for this terminology. 

If acceptable solution, I'll regenerate the documentation in this PR as well.