### PR TITLE
Proposed changes after TC + Willow workshop call November 17

### DIFF
--- a/Source/DTDLv2/Brick/Point/Point.json
+++ b/Source/DTDLv2/Brick/Point/Point.json
@@ -59,6 +59,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/Brick/Point/Point.json
+++ b/Source/DTDLv2/Brick/Point/Point.json
@@ -107,25 +107,6 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "External IDs"
-      },
-      "name": "externalIds",
-      "schema": {
-        "@type": "Map",
-        "mapKey": {
-          "name": "externalIdName",
-          "schema": "string"
-        },
-        "mapValue": {
-          "name": "externalIdValue",
-          "schema": "string"
-        }
-      },
-      "writable": true
-    },
-    {
-      "@type": "Property",
-      "displayName": {
         "en": "has quantity"
       },
       "name": "hasQuantity",
@@ -720,6 +701,25 @@
           }
         ],
         "valueSchema": "string"
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Identifiers"
+      },
+      "name": "identifiers",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "identifier",
+          "schema": "string"
+        }
       },
       "writable": true
     },

--- a/Source/DTDLv2/RealEstateCore/Agent/Agent.json
+++ b/Source/DTDLv2/RealEstateCore/Agent/Agent.json
@@ -5,6 +5,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/RealEstateCore/Agent/Agent.json
+++ b/Source/DTDLv2/RealEstateCore/Agent/Agent.json
@@ -53,17 +53,17 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "External IDs"
+        "en": "Identifiers"
       },
-      "name": "externalIds",
+      "name": "identifiers",
       "schema": {
         "@type": "Map",
         "mapKey": {
-          "name": "externalIdName",
+          "name": "namespace",
           "schema": "string"
         },
         "mapValue": {
-          "name": "externalIdValue",
+          "name": "identifier",
           "schema": "string"
         }
       },

--- a/Source/DTDLv2/RealEstateCore/Asset/Asset.json
+++ b/Source/DTDLv2/RealEstateCore/Asset/Asset.json
@@ -41,6 +41,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/RealEstateCore/Asset/Asset.json
+++ b/Source/DTDLv2/RealEstateCore/Asset/Asset.json
@@ -88,25 +88,6 @@
     },
     {
       "@type": "Property",
-      "displayName": {
-        "en": "External IDs"
-      },
-      "name": "externalIds",
-      "schema": {
-        "@type": "Map",
-        "mapKey": {
-          "name": "externalIdName",
-          "schema": "string"
-        },
-        "mapValue": {
-          "name": "externalIdValue",
-          "schema": "string"
-        }
-      },
-      "writable": true
-    },
-    {
-      "@type": "Property",
       "description": {
         "en": "A GeoJSON Polygon coordinate listing representing the geometrical representation of the asset. Coordinates may be expressed in two or three dimensions. Ex: [[30.0, 10.0, 0.0], [40.0, 40.0, 2.0], [20.0, 40.0, 2.0], [10.0, 20.0, 2.0], [30.0, 10.0, 0.0]]."
       },
@@ -115,6 +96,25 @@
       },
       "name": "geometry",
       "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Identifiers"
+      },
+      "name": "identifiers",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "identifier",
+          "schema": "string"
+        }
+      },
       "writable": true
     },
     {

--- a/Source/DTDLv2/RealEstateCore/BuildingElement/BuildingElement.json
+++ b/Source/DTDLv2/RealEstateCore/BuildingElement/BuildingElement.json
@@ -5,6 +5,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/RealEstateCore/BuildingElement/BuildingElement.json
+++ b/Source/DTDLv2/RealEstateCore/BuildingElement/BuildingElement.json
@@ -53,17 +53,17 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "External IDs"
+        "en": "Identifiers"
       },
-      "name": "externalIds",
+      "name": "identifiers",
       "schema": {
         "@type": "Map",
         "mapKey": {
-          "name": "externalIdName",
+          "name": "namespace",
           "schema": "string"
         },
         "mapValue": {
-          "name": "externalIdValue",
+          "name": "identifier",
           "schema": "string"
         }
       },

--- a/Source/DTDLv2/RealEstateCore/Collection/Collection.json
+++ b/Source/DTDLv2/RealEstateCore/Collection/Collection.json
@@ -5,6 +5,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/RealEstateCore/Collection/Collection.json
+++ b/Source/DTDLv2/RealEstateCore/Collection/Collection.json
@@ -53,17 +53,17 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "External IDs"
+        "en": "Identifiers"
       },
-      "name": "externalIds",
+      "name": "identifiers",
       "schema": {
         "@type": "Map",
         "mapKey": {
-          "name": "externalIdName",
+          "name": "namespace",
           "schema": "string"
         },
         "mapValue": {
-          "name": "externalIdValue",
+          "name": "identifier",
           "schema": "string"
         }
       },

--- a/Source/DTDLv2/RealEstateCore/Event/Event.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Event.json
@@ -5,6 +5,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/RealEstateCore/Event/Event.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Event.json
@@ -65,17 +65,17 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "External IDs"
+        "en": "Identifiers"
       },
-      "name": "externalIds",
+      "name": "identifiers",
       "schema": {
         "@type": "Map",
         "mapKey": {
-          "name": "externalIdName",
+          "name": "namespace",
           "schema": "string"
         },
         "mapValue": {
-          "name": "externalIdValue",
+          "name": "identifier",
           "schema": "string"
         }
       },

--- a/Source/DTDLv2/RealEstateCore/Information/Information.json
+++ b/Source/DTDLv2/RealEstateCore/Information/Information.json
@@ -5,6 +5,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",

--- a/Source/DTDLv2/RealEstateCore/Information/Information.json
+++ b/Source/DTDLv2/RealEstateCore/Information/Information.json
@@ -53,17 +53,17 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "External IDs"
+        "en": "Identifiers"
       },
-      "name": "externalIds",
+      "name": "identifiers",
       "schema": {
         "@type": "Map",
         "mapKey": {
-          "name": "externalIdName",
+          "name": "namespace",
           "schema": "string"
         },
         "mapValue": {
-          "name": "externalIdValue",
+          "name": "identifier",
           "schema": "string"
         }
       },

--- a/Source/DTDLv2/RealEstateCore/Space/Space.json
+++ b/Source/DTDLv2/RealEstateCore/Space/Space.json
@@ -63,25 +63,6 @@
     },
     {
       "@type": "Property",
-      "displayName": {
-        "en": "External IDs"
-      },
-      "name": "externalIds",
-      "schema": {
-        "@type": "Map",
-        "mapKey": {
-          "name": "externalIdName",
-          "schema": "string"
-        },
-        "mapValue": {
-          "name": "externalIdValue",
-          "schema": "string"
-        }
-      },
-      "writable": true
-    },
-    {
-      "@type": "Property",
       "description": {
         "en": "A GeoJSON Polygon coordinate listing representing the geometrical representation of the space. Coordinates may be expressed in two or three dimensions. Ex: [[30.0, 10.0, 0.0], [40.0, 40.0, 2.0], [20.0, 40.0, 2.0], [10.0, 20.0, 2.0], [30.0, 10.0, 0.0]]."
       },
@@ -90,6 +71,25 @@
       },
       "name": "geometry",
       "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Identifiers"
+      },
+      "name": "identifiers",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "identifier",
+          "schema": "string"
+        }
+      },
       "writable": true
     },
     {

--- a/Source/DTDLv2/RealEstateCore/Space/Space.json
+++ b/Source/DTDLv2/RealEstateCore/Space/Space.json
@@ -16,6 +16,35 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Custom Tags"
       },
       "name": "customTags",


### PR DESCRIPTION
Adopts Willow's style of nested map-based customProperties (string->(string->string)), allowing the outer key to indicate namespace, and the inner to indicate property within that namespace.

Renames externalIds to identifiers; the "external" terminology is not intuitive in scenarios where twin objects are produced or consumed in some pipeline outside of a digital twin platform.