### PR TITLE
fix: correct order of @type in ObservationEvents

### DIFF
--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AccelerationObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AccelerationObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Acceleration",
-        "Property"
+        "Property",
+        "Acceleration"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AngleObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AngleObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Angle",
-        "Property"
+        "Property",
+        "Angle"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AngularAccelerationObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AngularAccelerationObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "AngularAcceleration",
-        "Property"
+        "Property",
+        "AngularAcceleration"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AngularVelocityObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AngularVelocityObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "AngularVelocity",
-        "Property"
+        "Property",
+        "AngularVelocity"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AreaObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/AreaObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Area",
-        "Property"
+        "Property",
+        "Area"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/CapacitanceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/CapacitanceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Capacitance",
-        "Property"
+        "Property",
+        "Capacitance"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DataRateObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DataRateObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "DataRate",
-        "Property"
+        "Property",
+        "DataRate"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DataSizeObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DataSizeObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "DataSize",
-        "Property"
+        "Property",
+        "DataSize"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DensityObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DensityObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Density",
-        "Property"
+        "Property",
+        "Density"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DistanceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/DistanceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Distance",
-        "Property"
+        "Property",
+        "Distance"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ElectricChargeObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ElectricChargeObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "ElectricCharge",
-        "Property"
+        "Property",
+        "ElectricCharge"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ElectricCurrentObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ElectricCurrentObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Current",
-        "Property"
+        "Property",
+        "Current"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/EnergyObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/EnergyObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Energy",
-        "Property"
+        "Property",
+        "Energy"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ForceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ForceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Force",
-        "Property"
+        "Property",
+        "Force"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/FrequencyObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/FrequencyObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Frequency",
-        "Property"
+        "Property",
+        "Frequency"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/IlluminanceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/IlluminanceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Illuminance",
-        "Property"
+        "Property",
+        "Illuminance"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/InductanceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/InductanceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Inductance",
-        "Property"
+        "Property",
+        "Inductance"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LengthObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LengthObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Length",
-        "Property"
+        "Property",
+        "Length"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LuminanceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LuminanceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Luminance",
-        "Property"
+        "Property",
+        "Luminance"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LuminousFluxObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LuminousFluxObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "LuminousFlux",
-        "Property"
+        "Property",
+        "LuminousFlux"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LuminousIntensityObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/LuminousIntensityObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "LuminousIntensity",
-        "Property"
+        "Property",
+        "LuminousIntensity"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/MagneticFluxObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/MagneticFluxObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "MagneticFlux",
-        "Property"
+        "Property",
+        "MagneticFlux"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/MassFlowRateObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/MassFlowRateObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "MassFlowRate",
-        "Property"
+        "Property",
+        "MassFlowRate"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/MassObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/MassObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Mass",
-        "Property"
+        "Property",
+        "Mass"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/PowerObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/PowerObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Power",
-        "Property"
+        "Property",
+        "Power"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/PressureObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/PressureObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Pressure",
-        "Property"
+        "Property",
+        "Pressure"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/RelativeHumidityObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/RelativeHumidityObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "RelativeHumidity",
-        "Property"
+        "Property",
+        "RelativeHumidity"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ResistanceObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ResistanceObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Resistance",
-        "Property"
+        "Property",
+        "Resistance"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/SoundPressureObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/SoundPressureObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "SoundPressure",
-        "Property"
+        "Property",
+        "SoundPressure"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/TemperatureObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/TemperatureObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Temperature",
-        "Property"
+        "Property",
+        "Temperature"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ThrustObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/ThrustObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Thrust",
-        "Property"
+        "Property",
+        "Thrust"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/TimeSpanObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/TimeSpanObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "TimeSpan",
-        "Property"
+        "Property",
+        "TimeSpan"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/TorqueObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/TorqueObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Torque",
-        "Property"
+        "Property",
+        "Torque"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VelocityObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VelocityObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Velocity",
-        "Property"
+        "Property",
+        "Velocity"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VoltageObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VoltageObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Voltage",
-        "Property"
+        "Property",
+        "Voltage"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VolumeFlowRateObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VolumeFlowRateObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "VolumeFlowRate",
-        "Property"
+        "Property",
+        "VolumeFlowRate"
       ],
       "displayName": {
         "en": "value"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VolumeObservation.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ObservationEvent/VolumeObservation.json
@@ -4,8 +4,8 @@
   "contents": [
     {
       "@type": [
-        "Volume",
-        "Property"
+        "Property",
+        "Volume"
       ],
       "displayName": {
         "en": "value"


### PR DESCRIPTION
While debugging [issue](https://github.com/RealEstateCore/rec/issues/227) we found out that the problem was the order of the array `@type`.

According to Microsoft's [documentation](https://learn.microsoft.com/en-us/azure/digital-twins/concepts-models#semantic-type-example) "Property" must be the first element of the @type array:
> "Property" or "Telemetry" must be the first element of the @type array, followed by the semantic type. Otherwise, the field may not be visible in [Azure Digital Twins Explorer](https://learn.microsoft.com/en-us/azure/digital-twins/concepts-azure-digital-twins-explorer).

