### PR TITLE
start to add some brick deprecation annotations and suggested alternative location classes

### DIFF
--- a/Source/SHACL/Brick/brickpatches.ttl
+++ b/Source/SHACL/Brick/brickpatches.ttl
@@ -13,6 +13,10 @@
 
 brick:Ablutions_Room
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. There is not yet a replacement in REC for Ablutions_Room" ;
+  ]
 .
 brick:Absolute_Humidity_Sensor
   rdf:type owl:Class ;
@@ -80,33 +84,73 @@ brick:Angle_Sensor
 .
 brick:Atrium
   owl:deprecated "true"^^xsd:boolean ;
+    brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:Atrium" ;
+  ]
 .
 brick:Auditorium
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:Auditorium" ;
+  ]
 .
 brick:Basement
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:BasementLevel" ;
+  ]
 .
 brick:Battery_Room
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:ElectricityRoom" ;
+  ]
 .
 brick:Bench_Space
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider creating a rec:Zone that is part of a rec:Stadium" ;
+  ]
 .
 brick:Break_Room
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:BasementLevel" ;
+  ]
 .
 brick:Breakroom
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:StaffRoom" ;
+  ]
 .
 brick:Broadcast_Room
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:RecordingRoom" ;
+  ]
 .
 brick:Building
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:Building" ;
+  ]
 .
 brick:Cafeteria
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:CafeteriaRoom" ;
+  ]
 .
 brick:Capacity_Sensor
   sh:property [
@@ -120,6 +164,10 @@ brick:Capacity_Sensor
 .
 brick:Cold_Box
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:Laboratory" ;
+  ]
 .
 brick:Collection
   owl:deprecated "true"^^xsd:boolean ;
@@ -136,9 +184,17 @@ brick:Command
 .
 brick:Common_Space
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:Space" ;
+  ]
 .
 brick:Concession
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:FoodHandlingRoom" ;
+  ]
 .
 brick:Conductivity_Sensor
   sh:property [
@@ -152,6 +208,10 @@ brick:Conductivity_Sensor
 .
 brick:Conference_Room
   owl:deprecated "true"^^xsd:boolean ;
+    brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:ConferenceRoom" ;
+  ]
 .
 brick:Contact_Sensor
   sh:property [
@@ -165,12 +225,24 @@ brick:Contact_Sensor
 .
 brick:Control_Room
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:SecurityRoom" ;
+  ]
 .
 brick:Copy_Room
   owl:deprecated "true"^^xsd:boolean ;
+    brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:CopyingRoom" ;
+  ]
 .
 brick:Cubicle
   owl:deprecated "true"^^xsd:boolean ;
+  brick:deprecation [
+    brick:deprecatedInVersion "1.3.1" ;
+    brick:deprecationMitigationMessage "Brick location classes are being phased out in favor of RealEstateCore classes. For a replacement, consider rec:Workspace perhaps with a rec:Desk" ;
+  ]
 .
 brick:Current_Sensor
   sh:property [


### PR DESCRIPTION
In Brick we have some richer deprecation properties. This seems like a good place to start adding them, when we're done maybe we'll pull all of this out and put it back in brick and shrink this file overall. 

For now, we need to start thinking about what class should people use - in some cases it's a clear one-to-one match. There will be a few thing we'll want to add to REC, and in some cases what we had in Brick may not really be necessary. (I think we'll want to see ablution room added, not sure that we need some of the specialized stadium things added)

Brick has shacl rules for automatically adding some classes but I didn't start trying to add those. The Brick shacl rules automatically add `owl:deprecated` to things marked with `brick:deprecation` but we can leave that in here for now if it's easier. 