### PR TITLE
Fix PV_Panel enum values to be arrays instead of objects

### DIFF
--- a/Source/DTDLv2/Brick/Asset/Equipment/PV_Panel/PV_Panel.json
+++ b/Source/DTDLv2/Brick/Asset/Equipment/PV_Panel/PV_Panel.json
@@ -19,10 +19,10 @@
             "name": "hasUnit",
             "schema": {
               "@type": "Enum",
-              "enumValues": {
+              "enumValues": [{
                 "enumValue": "PERCENT",
                 "name": "PERCENT"
-              },
+              }],
               "valueSchema": "string"
             }
           }
@@ -47,10 +47,10 @@
             "name": "hasUnit",
             "schema": {
               "@type": "Enum",
-              "enumValues": {
+              "enumValues": [{
                 "enumValue": "PERCENT",
                 "name": "PERCENT"
-              },
+              }],
               "valueSchema": "string"
             }
           }


### PR DESCRIPTION
Current definition of PV_Panel enum values causes the break of Azure Digital Twin explorer. After change of type from object to array of objects, tool start to function correctly.