### PR TITLE
Remove sh:minCount 1 for Asset locatedIn

### DIFF
--- a/Source/SHACL/RealEstateCore/rec.ttl
+++ b/Source/SHACL/RealEstateCore/rec.ttl
@@ -462,7 +462,6 @@ rec:Asset
       rdf:type sh:PropertyShape ;
       sh:path rec:locatedIn ;
       sh:class rec:Space ;
-      sh:minCount 1 ;
       sh:name "located in" ;
       sh:nodeKind sh:IRI ;
     ] ;


### PR DESCRIPTION
- I believe this now matches the multiplicity of the `locatedIn` relationship on `rec:Asset` as modeled in DTDL
- makes REC more compatible with Brick, which does not require locations for any entities

I didn't see a `CONTRIBUTING.md` file with specific instructions for PRs, but let me know if there is anything else I should change! 