### PR TITLE
Proposal to add properties and relationships to Alarms

### DIFF
--- a/Source/DTDLv2/Brick/Point/Alarm/Alarm.json
+++ b/Source/DTDLv2/Brick/Point/Alarm/Alarm.json
@@ -9,6 +9,19 @@
       },
       "name": "lastKnownValue",
       "schema": "dtmi:org:w3id:rec:ExceptionEvent;1"
+    },
+    {
+      "@type": "Relationship",
+      "description": {
+        "en": "The brick:Point that emitted this exception."
+      },
+      "displayName": {
+        "en": "source point"
+      },
+      "maxMultiplicity": 1,
+      "name": "sourcePoint",
+      "target": "dtmi:org:brickschema:schema:Brick:Point;1",
+      "writable": true
     }
   ],
   "description": {

--- a/Source/DTDLv2/RealEstateCore/Event/Event.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Event.json
@@ -65,6 +65,18 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "Event Identifier"
+      },
+      "description": {
+        "en": "Some events (like exception events) generate a unique identifier to enable traceability and management of the event through it's lifecycle."
+      },
+      "name": "eventIdentifier",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "Identifiers"
       },
       "name": "identifiers",
@@ -88,6 +100,18 @@
       },
       "name": "name",
       "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Priority"
+      },
+      "description": {
+        "en": "Reflect the importance or urgency of the event. Determines the order in which the system or the operators should address the event."
+      },
+      "name": "priority",
+      "schema": "integer",
       "writable": true
     },
     {

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ExceptionEvent.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ExceptionEvent.json
@@ -5,6 +5,100 @@
     {
       "@type": "Property",
       "description": {
+        "en": "The previous state of the event."
+      },
+      "displayName": {
+        "en": "from state"
+      },
+      "name": "fromState",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "normal",
+            "displayName": "Normal",
+            "enumValue": 0
+          },
+          {
+            "name": "fault",
+            "displayName": "Fault",
+            "enumValue": 1
+          },
+          {
+            "name": "offnormal",
+            "displayName": "Offnormal",
+            "enumValue": 2
+          },
+          {
+            "name": "highLimit",
+            "displayName": "High Limit",
+            "enumValue": 3
+          },
+          {
+            "name": "lowLimit",
+            "displayName": "Low Limit",
+            "enumValue": 4
+          },
+          {
+            "name": "lifeSafetyAlarm",
+            "displayName": "Life Safety Alarm",
+            "enumValue": 5
+          }
+        ]
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "description": {
+        "en": "The current state of the event."
+      },
+      "displayName": {
+        "en": "to state"
+      },
+      "name": "toState",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "normal",
+            "displayName": "Normal",
+            "enumValue": 0
+          },
+          {
+            "name": "fault",
+            "displayName": "Fault",
+            "enumValue": 1
+          },
+          {
+            "name": "offnormal",
+            "displayName": "Offnormal",
+            "enumValue": 2
+          },
+          {
+            "name": "highLimit",
+            "displayName": "High Limit",
+            "enumValue": 3
+          },
+          {
+            "name": "lowLimit",
+            "displayName": "Low Limit",
+            "enumValue": 4
+          },
+          {
+            "name": "lifeSafetyAlarm",
+            "displayName": "Life Safety Alarm",
+            "enumValue": 5
+          }
+        ]
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "description": {
         "en": "The message of this exception event."
       },
       "displayName": {
@@ -17,7 +111,7 @@
     {
       "@type": "Relationship",
       "description": {
-        "en": "The brick:Point that emitted this exception."
+        "en": "The brick:Point that emitted this observation."
       },
       "displayName": {
         "en": "source point"

--- a/Source/DTDLv2/RealEstateCore/Event/Point-/ExceptionEvent.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Point-/ExceptionEvent.json
@@ -111,7 +111,7 @@
     {
       "@type": "Relationship",
       "description": {
-        "en": "The brick:Point that emitted this observation."
+        "en": "The brick:Point that emitted this exception."
       },
       "displayName": {
         "en": "source point"


### PR DESCRIPTION
Working through modeling BACnet and Niagara Edge Alarms, I'd like to propose:
- Alarm:
  - ADD `sourcePoint` relationship: Alarm should reference the Point/Points that are the source of the Alarm.
- Event
  - ADD `eventIdentifier` property: It's common for events to either generate a unique identifier, or use a reference number. This enables the events to be tracked and managed throughout it's lifecycle (important for ACK/clear on alarms)
  - ADD `priority` property: It's common for controller events to have an associated priority in order to understand how the system or operators should order their responses.
- ExceptionEvent
  - ADD `fromState` and `toState` properties: Common pattern I'm seeing on controllers is capturing both from and to state, not just the generated message.

I'm still working through with my teams how to capture acknowledge and clear of exception events, and plan to expand this PR. I'm also planning on capturing common alarm configurations (High limit, deadband, etc)