### PR TITLE
Update double extends from wet bulb temperature sensors, remove tags

### DIFF
--- a/Source/DTDLv2/Brick/Point/Sensor/Temperature-/Air-/Air_Wet_Bulb_Temperature_Sensor/Air_Wet_Bulb_Temperature_Sensor.json
+++ b/Source/DTDLv2/Brick/Point/Sensor/Temperature-/Air-/Air_Wet_Bulb_Temperature_Sensor/Air_Wet_Bulb_Temperature_Sensor.json
@@ -4,11 +4,6 @@
   "displayName": {
     "en": "Air Wet Bulb Temperature Sensor"
   },
-  "extends": [
-    "dtmi:org:brickschema:schema:Brick:Temperature_Sensor;1",
-    "dtmi:org:brickschema:schema:Brick:Air_Temperature_Sensor;1"
-  ],
-  "@context": [
-    "dtmi:dtdl:context;2"
-  ]
+  "extends": ["dtmi:org:brickschema:schema:Brick:Air_Temperature_Sensor;1"],
+  "@context": ["dtmi:dtdl:context;2"]
 }

--- a/Source/DTDLv2/Brick/Point/Sensor/Temperature-/Air-/Air_Wet_Bulb_Temperature_Sensor/Outside-.json
+++ b/Source/DTDLv2/Brick/Point/Sensor/Temperature-/Air-/Air_Wet_Bulb_Temperature_Sensor/Outside-.json
@@ -1,40 +1,12 @@
 {
   "@id": "dtmi:org:brickschema:schema:Brick:Outside_Air_Wet_Bulb_Temperature_Sensor;1",
   "@type": "Interface",
-  "contents": [
-    {
-      "@type": "Property",
-      "description": {
-        "en": "Brick tags associated with this interface."
-      },
-      "displayName": {
-        "en": "Tags"
-      },
-      "name": "tags",
-      "schema": {
-        "@type": "Map",
-        "mapKey": {
-          "name": "tagName",
-          "schema": "string"
-        },
-        "mapValue": {
-          "name": "tagValue",
-          "schema": "boolean"
-        }
-      }
-    }
-  ],
   "description": {
     "en": "A sensor measuring the wet-bulb temperature of outside air"
   },
   "displayName": {
     "en": "Outside Air Wet Bulb Temperature Sensor"
   },
-  "extends": [
-    "dtmi:org:brickschema:schema:Brick:Outside_Air_Temperature_Sensor;1",
-    "dtmi:org:brickschema:schema:Brick:Air_Wet_Bulb_Temperature_Sensor;1"
-  ],
-  "@context": [
-    "dtmi:dtdl:context;2"
-  ]
+  "extends": ["dtmi:org:brickschema:schema:Brick:Air_Temperature_Sensor;1"],
+  "@context": ["dtmi:dtdl:context;2"]
 }


### PR DESCRIPTION
Update double extends from wet bulb temperature sensors, remove tags from outside air wet bulb temperature sensor. The models are currently causing visual bugs in the azure digital twins explorer.