### PR TITLE
Logical Device

### DIFF
--- a/Source/DTDLv2/RealEstateCore/LogicalDevice/LogicalDevice.json
+++ b/Source/DTDLv2/RealEstateCore/LogicalDevice/LogicalDevice.json
@@ -1,0 +1,108 @@
+{
+  "@id": "dtmi:org:w3id:rec:LogicalDevice;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "located in"
+      },
+      "name": "locatedIn",
+      "target": "dtmi:org:w3id:rec:Space;1",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "served by"
+      },
+      "name": "servedBy",
+      "target": "dtmi:org:w3id:rec:LogicalDevice;1",
+      "maxMultiplicity": 1,
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "serves"
+      },
+      "name": "serves",
+      "target": "dtmi:org:w3id:rec:LogicalDevice;1",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "connector type"
+      },
+      "name": "connectorType",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "connector name"
+      },
+      "name": "connectorName",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Custom Tags"
+      },
+      "name": "customTags",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "tagName",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "tagValue",
+          "schema": "boolean"
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Identifiers"
+      },
+      "name": "identifiers",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "identifier",
+          "schema": "string"
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "name"
+      },
+      "name": "name",
+      "schema": "string",
+      "writable": true
+    }
+  ],
+  "description": {
+    "en": "Logical Device."
+  },
+  "displayName": {
+    "en": "LogicalDevice"
+  },
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/Source/DTDLv2/RealEstateCore/LogicalDevice/LogicalDevice.json
+++ b/Source/DTDLv2/RealEstateCore/LogicalDevice/LogicalDevice.json
@@ -31,21 +31,12 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": "Relationship",
       "displayName": {
-        "en": "connector type"
+        "en": "has point"
       },
-      "name": "connectorType",
-      "schema": "string",
-      "writable": true
-    },
-    {
-      "@type": "Property",
-      "displayName": {
-        "en": "connector name"
-      },
-      "name": "connectorName",
-      "schema": "string",
+      "name": "hasPoint",
+      "target": "dtmi:org:w3id:rec:GatewayConnectionParameter;1",
       "writable": true
     },
     {

--- a/Source/DTDLv2/RealEstateCore/LogicalDevice/LogicalServer/LogicalServer.json
+++ b/Source/DTDLv2/RealEstateCore/LogicalDevice/LogicalServer/LogicalServer.json
@@ -1,0 +1,25 @@
+{
+  "@id": "dtmi:org:w3id:rec:LogicalServer;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "IP address"
+      },
+      "name": "IPAddress",
+      "schema": "string",
+      "writable": true
+    }
+  ],
+  "description": {
+    "en": "Logical Server."
+  },
+  "displayName": {
+    "en": "LogicalServer"
+  },
+  "extends": "dtmi:org:w3id:rec:LogicalDevice;1",
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/Source/DTDLv2/RealEstateCore/Point/Parameter/Gateway-/GatewayConnectionParameter.json
+++ b/Source/DTDLv2/RealEstateCore/Point/Parameter/Gateway-/GatewayConnectionParameter.json
@@ -3,6 +3,17 @@
     "@type": "Interface",
     "displayName": "Gateway Connection Parameter",
     "extends": "dtmi:org:brickschema:schema:Brick:Parameter;1",
+    "contents": [
+        {
+            "@type": "Property",
+            "displayName": {
+                "en": "gateway type"
+            },
+            "name": "gatewayType",
+            "schema": "string",
+            "writable": true
+        }
+    ],
     "@context": [
         "dtmi:dtdl:context;2"
     ]


### PR DESCRIPTION
**LogicalDevice** is a new base class to represent a connected entity that pushes data to the cloud, which is typically an instance of a piece of software (e.g., an IoTEdge module, a HomeAssistant install, some proprietary BMS system, etc).
Relations:
- serves - The coverage or impact device of a given LogicalDevice.
- servedBy - Indicates that an LogicalDevice is served by some device or sensor.
- hasPoint - point:[GatewayConnectionParameter](https://dev.realestatecore.io/ontology/Point/Parameter/GatewayConnection-/GatewayConnectionParameter).

GatewayConnectionParameter was extended with a new property 'gatewayType'.

**Display name:** LogicalDevice
**DTMI:** dtmi:org:w3id:rec:LogicalDevice;1

**LogicalServer** is a subclass of LogicalDevice, extended with the property "IPAddress".