### PR TITLE
SpaceCollection improvement

### DIFF
--- a/Source/DTDLv2/RealEstateCore/Collection/Space-.json
+++ b/Source/DTDLv2/RealEstateCore/Collection/Space-.json
@@ -1,0 +1,25 @@
+{
+  "@id": "dtmi:org:w3id:rec:SpaceCollection;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "includes"
+      },
+      "name": "includes",
+      "target": "dtmi:org:w3id:rec:Space;1",
+      "writable": true
+    }
+  ],
+  "description": {
+    "en": "Grouping of any spaces."
+  },
+  "displayName": {
+    "en": "Space Collection"
+  },
+  "extends": "dtmi:org:w3id:rec:Collection;1",
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}


### PR DESCRIPTION
A new subclass of [Collection](https://dev.realestatecore.io/ontology/Collection/Collection) interface to group any kind of space.
Inherits all Collection components, "includes" relation has [Space class](https://dev.realestatecore.io/ontology/Space/Space) as a target, multiplicity is 0-Infinity.

REC3 had SpaceCollection which is motivation in itself.
There is no equivalent in REC4. The closest REC4 classes are:

- A zone is not free enough, e.g. as it can not group rooms from multiple levels.
- “Premises” collection has a different semantical meaning and would be misleading.
- Area is only a quantity, not a geometry or group of spaces and/or geometries.

There are several practical cases where spaces need to be grouped, e.g. to keep track of the heated, cooled, rentable, or high-security part of a building. The need spans maintenance, administration technical configuration, and tenant experience.

**Display name:** SpaceCollection
**DTMI:** dtmi:org:w3id:rec:SpaceCollection;1