### PR TITLE
PointGroup

### DIFF
--- a/Source/DTDLv2/Brick/Point/Point.json
+++ b/Source/DTDLv2/Brick/Point/Point.json
@@ -739,6 +739,26 @@
       },
       "name": "isPointOf",
       "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "has location"
+      },
+      "name": "hasLocation",
+      "target": "dtmi:org:w3id:rec:Architecture;1",
+      "writable": true,
+      "maxMultiplicity": 1
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "is member of"
+      },
+      "name": "isMemberOf",
+      "target": "dtmi:org:w3id:rec:PointGroup;1",
+      "writable": true,
+      "maxMultiplicity": 1
     }
   ],
   "displayName": {

--- a/Source/DTDLv2/Brick/Point/Point.json
+++ b/Source/DTDLv2/Brick/Point/Point.json
@@ -743,9 +743,9 @@
     {
       "@type": "Relationship",
       "displayName": {
-        "en": "has location"
+        "en": "located in"
       },
-      "name": "hasLocation",
+      "name": "locatedIn",
       "target": "dtmi:org:w3id:rec:Architecture;1",
       "writable": true,
       "maxMultiplicity": 1

--- a/Source/DTDLv2/RealEstateCore/PointGroup/PointGroup.json
+++ b/Source/DTDLv2/RealEstateCore/PointGroup/PointGroup.json
@@ -1,0 +1,79 @@
+{
+  "@id": "dtmi:org:w3id:rec:PointGroup;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "located in"
+      },
+      "name": "locatedIn",
+      "target": "dtmi:org:w3id:rec:Space;1",
+      "maxMultiplicity": 1,
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "has point"
+      },
+      "name": "hasPoint",
+      "target": "dtmi:org:w3id:rec:Point;1",
+      "writable": true
+    },
+
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Custom Tags"
+      },
+      "name": "customTags",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "tagName",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "tagValue",
+          "schema": "boolean"
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Identifiers"
+      },
+      "name": "identifiers",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "identifier",
+          "schema": "string"
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "name"
+      },
+      "name": "name",
+      "schema": "string",
+      "writable": true
+    }
+  ],
+  "displayName": {
+    "en": "Point Group"
+  },
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/Source/DTDLv2/RealEstateCore/PointGroup/PointGroup.json
+++ b/Source/DTDLv2/RealEstateCore/PointGroup/PointGroup.json
@@ -18,7 +18,16 @@
         "en": "has member"
       },
       "name": "hasMember",
-      "target": "dtmi:org:w3id:rec:Point;1",
+      "target": "dtmi:org:brickschema:schema:Brick:Point;1",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "is point group of"
+      },
+      "name": "isPointGroupOf",
+      "target": "dtmi:org:w3id:rec:Asset;1",
       "writable": true
     },
 

--- a/Source/DTDLv2/RealEstateCore/PointGroup/PointGroup.json
+++ b/Source/DTDLv2/RealEstateCore/PointGroup/PointGroup.json
@@ -15,9 +15,9 @@
     {
       "@type": "Relationship",
       "displayName": {
-        "en": "has point"
+        "en": "has member"
       },
-      "name": "hasPoint",
+      "name": "hasMember",
       "target": "dtmi:org:w3id:rec:Point;1",
       "writable": true
     },


### PR DESCRIPTION
### **PointGroup**

PointGroup is a new base class to represent an abstract entity to group [Points and all subclasses](https://dev.realestatecore.io/ontology/Point/Point). Point group is equivalent to REC Device. There is Equipment in REC4, which is an asset and represents the physical aspect of “devices” as they are commonly understood. Therefore, it would be misleading to use the “device” label. However, there is a common need to represent the abstract grouping of points (e.g. as they are modeled in a control system) where oftentimes either the physical grouping is not known, or where there might not be any physical group - no Equipment. Apart from representing a control system model, there is a need to group points into abstract objects that communicate jointly.

There are Collection subclasses that relate to strictly physical groupings (e.g. EquipmentCollection), and larger collections e.g. System. There is no suitable affordance in REC4.
Furthermore, since Points are organized in hierarchies that span multiple levels, and REC does not allow for collections of collections, it is not possible to model these multi-level hierarchies with a collection at all. Hence we suggest that PointGroup is a new base class.


This entity contains two relations:
- locatedIn - target class Space;
- hasMember - target class Point;

**locatedIn** - is a relation to show the main location (Space) of all Points, that are grouped.
**hasMember** - represents all Points included in the group, reverse relation to "isMemberOf".

**Display name:** PointGroup
**DTMI:** dtmi:org:w3id:rec:PointGroup;1

### **Point relations**
Alongside the new PointGroup base class, Point and all subclasses are extended with a new relation - isMemberOf.
"isMemberOf" has a target class "PointGroup".

Also to separate relations in Point between Asset and Space, a new relation in Point class was added - locatedIn relation indicates an exact Space where Point is located.

