### PR TITLE
Added Warranty class and Asset properties

### DIFF
--- a/Source/DTDLv2/RealEstateCore/Asset/Asset.json
+++ b/Source/DTDLv2/RealEstateCore/Asset/Asset.json
@@ -32,6 +32,15 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "colour"
+      },
+      "name": "colour",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "commissioning date"
       },
       "name": "commissioningDate",
@@ -282,6 +291,15 @@
       },
       "name": "servicedBy",
       "target": "dtmi:org:w3id:rec:Agent;1",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "warranty"
+      },
+      "name": "warranty",
+      "target": "dtmi:org:w3id:rec:Warranty;1",
       "writable": true
     }
   ],

--- a/Source/DTDLv2/RealEstateCore/Event/Warranty.json
+++ b/Source/DTDLv2/RealEstateCore/Event/Warranty.json
@@ -1,0 +1,14 @@
+{
+  "@id": "dtmi:org:w3id:rec:Warranty;1",
+  "@type": "Interface",
+  "extends": "dtmi:org:w3id:rec:Event;1",
+  "description": {
+    "en": "Represents warranty information for an asset."
+  },
+  "displayName": {
+    "en": "Warranty"
+  },
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}


### PR DESCRIPTION
## Add Warranty class and colour property to Asset

### Summary

This PR is part of the broader effort to support lighting assets in RealEstateCore, with most of the foundational work happening in Brick Schema. On the REC side, this adds:

- **New `Warranty` class** (`dtmi:org:w3id:rec:Warranty;1`) — extends `Event` to represent warranty information for assets
- **New `warranty` relationship on `Asset`** — links assets to their warranty records
- **New `colour` property on `Asset`** — string property to capture asset colour

### Changes

| File | Change |
|------|--------|
| `Source/DTDLv2/RealEstateCore/Asset/Asset.json` | Added `colour` property and `warranty` relationship |
| `Source/DTDLv2/RealEstateCore/Event/Warranty.json` | New interface extending `Event` |

### Context

These additions complement the lighting equipment classes already defined via Brick Schema (`Lighting_Equipment`, `Luminaire`, `Luminaire_Driver`, etc.) by providing asset-level metadata (colour, warranty) that is relevant across all asset types, including lighting.
