### PR TITLE
claude/debug-merge-action-7eH7g

### DIFF
--- a/.github/workflows/merge_and_document.yml
+++ b/.github/workflows/merge_and_document.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build DTDL Merger
       run: dotnet build ./Tools/DTDLMerger/
     - name: Run DTDL Merger on REC DTDLv2
-      run: dotnet run --project ./Tools/DTDLMerger/ ./Source/DTDLv2/ > ./RealEstateCore.DTDLv2.jsonld
+      run: dotnet run --project ./Tools/DTDLMerger/ --no-build -- ./Source/DTDLv2/ > ./RealEstateCore.DTDLv2.jsonld
     - name: Increment .nuspec revision number
       id: increment
       uses: vers-one/dotnet-project-version-updater@v1.2


### PR DESCRIPTION
The new .NET 10 SDK on the runner emits NETSDK1138 for the net6.0
target. `dotnet run` re-runs the build and writes that warning to
stdout; the `>` redirect on this step captured it into
RealEstateCore.DTDLv2.jsonld, so DTDL2MD then crashed parsing a file
that began with the MSBuild warning path (`/usr/share/dotnet/...`).

Add --no-build (the preceding step already built the project) so the
redirect only captures the program's JSON output.