### PR TITLE
Install Mono before nuget setup on Linux runner

### DIFF
--- a/.github/workflows/push_to_nuget.yml
+++ b/.github/workflows/push_to_nuget.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Install Mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
       - name: 'Setup Nuget'
         uses: nuget/setup-nuget@v1
         with:


### PR DESCRIPTION
## Summary

- Installs `mono-complete` via apt before the `nuget/setup-nuget@v1` step
- Fixes exit code 127 when invoking the Windows `nuget.exe` on the Linux runner

## Context

The v4.1.0 release publish [failed](https://github.com/RealEstateCore/rec/actions/runs/28378794695) with:

```
##[error]The process '/opt/hostedtoolcache/nuget.exe/5.11.7/x64/nuget' failed with exit code 127
```

`nuget/setup-nuget@v1` installs `nuget.exe` (a Windows binary) and ships a `nuget` wrapper script that requires Mono to execute it on Linux. Recent `ubuntu-latest` runner images no longer include Mono by default, which is why this workflow worked at v4.0.0 but breaks now. The failure happens immediately after install (during `setApiKey`), before any pack/push logic runs.

## Test plan

- [ ] Once merged, re-trigger `Package and push ontology to nuget.org` via `workflow_dispatch` against `main` (the existing v4.1.0 release will not fire it again automatically)
- [ ] Verify `4.1.0.0` appears on https://www.nuget.org/packages/RealEstateCore.Ontology.DTDLv2/

https://claude.ai/code/session_01EQxvebkZirhSQDU5UVSmRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQxvebkZirhSQDU5UVSmRV)_